### PR TITLE
Add support for limiting access to groups in a specific grouping

### DIFF
--- a/lib.php
+++ b/lib.php
@@ -19,8 +19,8 @@ function bigbluebuttonbn_supports($feature) {
     switch($feature) {
         case FEATURE_IDNUMBER:                return true;
         case FEATURE_GROUPS:                  return true;
-        case FEATURE_GROUPINGS:               return false;
-        case FEATURE_GROUPMEMBERSONLY:        return false;
+        case FEATURE_GROUPINGS:               return true;
+        case FEATURE_GROUPMEMBERSONLY:        return true;
         case FEATURE_MOD_INTRO:               return false;
         case FEATURE_COMPLETION_TRACKS_VIEWS: return true;
         case FEATURE_GRADE_HAS_GRADE:         return false;


### PR DESCRIPTION
We typically have multiple groupings for different events. Users are almost always in multiple groups.
To actually make Groups useful, support for groupings should be enabled. This will ensure that only those groups within the specified grouping are shown.

This should 'Just Work' out of the box once this setting is enabled.
