### PR TITLE
Fixing lang strings to improve translations

### DIFF
--- a/lang/en/bigbluebuttonbn.php
+++ b/lang/en/bigbluebuttonbn.php
@@ -163,7 +163,6 @@ $string['mod_form_field_notification_created_help'] = 'Send a notification to us
 $string['mod_form_field_notification_modified_help'] = 'Send a notification to users enrolled to let them know that this activity has been modified';
 $string['mod_form_field_notification_msg_created'] = 'created';
 $string['mod_form_field_notification_msg_modified'] = 'modified';
-$string['mod_form_field_notification_msg_at'] = 'at';
 
 
 $string['modulename'] = 'BigBlueButtonBN';
@@ -289,15 +288,15 @@ $string['predefined_profile_collaborationroom'] = 'Collaboration room';
 $string['predefined_profile_scheduledsession'] = 'Scheduled session';
 
 
-$string['email_title_notification_has_been'] = 'has been';
-$string['email_body_notification_meeting_has_been'] = 'has been';
-$string['email_body_notification_meeting_details'] = 'Details';
-$string['email_body_notification_meeting_title'] = 'Title';
-$string['email_body_notification_meeting_description'] = 'Description';
-$string['email_body_notification_meeting_start_date'] = 'Start date';
-$string['email_body_notification_meeting_end_date'] = 'End date';
-$string['email_body_notification_meeting_by'] = 'by';
-$string['email_body_recording_ready_for'] = 'Recording for';
-$string['email_body_recording_ready_is_ready'] = 'is ready';
-$string['email_footer_sent_by'] = 'This automatic notification message was sent by';
-$string['email_footer_sent_from'] = 'from the course';
+$string['email_date'] = '{$a->day} at {$a->time}';
+$string['email_footer'] = '<p><hr/><br/>This automatic notification message was sent by {$a->user_name}({$a->user_email}) '.
+        'from the course {$a->course_name}</p>';
+$string['email_body_notification'] = '<p>{$a->activity_type} &quot;{$a->activity_title}&quot; has been {$a->action}</p>'.
+        '<p><b>{$a->activity_title}</b> Details: '.
+        '<table border="0" style="margin: 5px 0 0 20px"><tbody>'.
+        '<tr><td style="font-weight:bold;color:#555;">Title: </td><td>{$a->activity_title}</td></tr>'.
+        '<tr><td style="font-weight:bold;color:#555;">Description: </td><td>{$a->activity_description}</td></tr>'.
+        '<tr><td style="font-weight:bold;color:#555;">Start date: </td><td>{$a->activity_openingtime}</td></tr>'.
+        '<tr><td style="font-weight:bold;color:#555;">End date: </td><td>{$a->activity_closingtime}</td></tr>'.
+        '<tr><td style="font-weight:bold;color:#555;">{$a->action} by: </td><td>{$a->activity_owner}</td></tr></tbody></table></p>';
+$string['email_body_recording'] = '<p>Recording for {$a->activity_type} &quot;{$a->activity_title}&quot; is ready</p>';

--- a/lib.php
+++ b/lib.php
@@ -385,7 +385,6 @@ function bigbluebuttonbn_process_post_save(&$bigbluebuttonbn) {
     } else {
         $action = get_string('mod_form_field_notification_msg_modified', 'bigbluebuttonbn');
     }
-    $at = get_string('mod_form_field_notification_msg_at', 'bigbluebuttonbn');
 
     // Add evento to the calendar when if openingtime is set
     if ( isset($bigbluebuttonbn->openingtime) && $bigbluebuttonbn->openingtime ){
@@ -425,7 +424,6 @@ function bigbluebuttonbn_process_post_save(&$bigbluebuttonbn) {
         if( isset($bigbluebuttonbn->type) && $bigbluebuttonbn->type != 0 )
             $msg->activity_type = bigbluebuttonbn_get_predefinedprofile_name($bigbluebuttonbn->type);
         $msg->activity_title = $bigbluebuttonbn->name;
-        $message_text = '<p>'.$msg->activity_type.' &quot;'.$msg->activity_title.'&quot; '.get_string('email_body_notification_meeting_has_been', 'bigbluebuttonbn').' '.$msg->action.'.</p>';
 
         /// Add the meeting details to the message_body
         $msg->action = ucfirst($action);
@@ -434,26 +432,21 @@ function bigbluebuttonbn_process_post_save(&$bigbluebuttonbn) {
             $msg->activity_description = trim($bigbluebuttonbn->intro);
         $msg->activity_openingtime = "";
         if ($bigbluebuttonbn->openingtime) {
-            $msg->activity_openingtime = calendar_day_representation($bigbluebuttonbn->openingtime).' '.$at.' '.calendar_time_representation($bigbluebuttonbn->openingtime);
+            $date = new stdClass();
+            $date->day = calendar_day_representation($bigbluebuttonbn->openingtime);
+            $date->time = calendar_time_representation($bigbluebuttonbn->openingtime);
+            $msg->activity_openingtime = get_string('email_date', 'bigbluebuttonbn', $date);
         }
         $msg->activity_closingtime = "";
         if ($bigbluebuttonbn->closingtime ) {
-            $msg->activity_closingtime = calendar_day_representation($bigbluebuttonbn->closingtime).' '.$at.' '.calendar_time_representation($bigbluebuttonbn->closingtime);
+            $date = new stdClass();
+            $date->day = calendar_day_representation($bigbluebuttonbn->closingtime);
+            $date->time = calendar_time_representation($bigbluebuttonbn->closingtime);
+            $msg->activity_closingtime = get_string('email_date', 'bigbluebuttonbn', $date);
         }
-        $msg->activity_owner = $USER->firstname.' '.$USER->lastname;
+        $msg->activity_owner = fullname($USER);
 
-        $message_text .= '<p><b>'.$msg->activity_title.'</b> '.get_string('email_body_notification_meeting_details', 'bigbluebuttonbn').':';
-        $message_text .= '<table border="0" style="margin: 5px 0 0 20px"><tbody>';
-        $message_text .= '<tr><td style="font-weight:bold;color:#555;">'.get_string('email_body_notification_meeting_title', 'bigbluebuttonbn').': </td><td>';
-        $message_text .= $msg->activity_title.'</td></tr>';
-        $message_text .= '<tr><td style="font-weight:bold;color:#555;">'.get_string('email_body_notification_meeting_description', 'bigbluebuttonbn').': </td><td>';
-        $message_text .= $msg->activity_description.'</td></tr>';
-        $message_text .= '<tr><td style="font-weight:bold;color:#555;">'.get_string('email_body_notification_meeting_start_date', 'bigbluebuttonbn').': </td><td>';
-        $message_text .= $msg->activity_openingtime.'</td></tr>';
-        $message_text .= '<tr><td style="font-weight:bold;color:#555;">'.get_string('email_body_notification_meeting_end_date', 'bigbluebuttonbn').': </td><td>';
-        $message_text .= $msg->activity_closingtime.'</td></tr>';
-        $message_text .= '<tr><td style="font-weight:bold;color:#555;">'.$msg->action.' '.get_string('email_body_notification_meeting_by', 'bigbluebuttonbn').': </td><td>';
-        $message_text .= $msg->activity_owner.'</td></tr></tbody></table></p>';
+        $message_text = get_string('email_body_notification', 'bigbluebuttonbn', $msg);
 
         // Send notification to all users enrolled
         bigbluebuttonbn_send_notification($USER, $bigbluebuttonbn, $message_text);
@@ -631,12 +624,11 @@ function bigbluebuttonbn_send_notification($sender, $bigbluebuttonbn, $message="
 
     //Complete message
     $msg = new stdClass();
-    $msg->user_name = $sender->firstname.' '.$sender->lastname;
+    $msg->user_name = fullname($sender);
     $msg->user_email = $sender->email;
-    $msg->course_name = "$course->fullname";
-    $message .= '<p><hr/><br/>'.get_string('email_footer_sent_by', 'bigbluebuttonbn').' '.$msg->user_name.'('.$msg->user_email.') ';
-    $message .= get_string('email_footer_sent_from', 'bigbluebuttonbn').' '.$msg->course_name.'.</p>';
-    
+    $msg->course_name = $course->fullname;
+    $message .= get_string('email_footer', 'bigbluebuttonbn', $msg);
+
     $users = bigbluebuttonbn_get_users($context);
     foreach( $users as $user ) {
         if( $user->id != $sender->id ){

--- a/locallib.php
+++ b/locallib.php
@@ -1095,8 +1095,8 @@ function bigbluebuttonbn_send_notification_recording_ready($bigbluebuttonbn) {
     if( isset($bigbluebuttonbn->type) && $bigbluebuttonbn->type != 0 )
         $msg->activity_type = bigbluebuttonbn_get_predefinedprofile_name($bigbluebuttonbn->type);
     $msg->activity_title = $bigbluebuttonbn->name;
-    $message_text = '<p>'.get_string('email_body_recording_ready_for', 'bigbluebuttonbn').' '.$msg->activity_type.' &quot;'.$msg->activity_title.'&quot; '.get_string('email_body_recording_ready_is_ready', 'bigbluebuttonbn').'.</p>';
     
+    $message_text = get_string('email_body_recording', 'bigbluebuttonbn', $msg);
     bigbluebuttonbn_send_notification($sender, $bigbluebuttonbn, $message_text);
 }
 

--- a/view.php
+++ b/view.php
@@ -52,7 +52,7 @@ $bbbsession['bigbluebuttonbnid'] = $bigbluebuttonbn->id;
 $bbbsession['bigbluebuttonbntype'] = $bigbluebuttonbn->type;
 
 // User data
-$bbbsession['username'] = get_string('fullnamedisplay', 'moodle', $USER);
+$bbbsession['username'] = fullname($USER);
 $bbbsession['userID'] = $USER->id;
 $bbbsession['roles'] = get_user_roles($context, $USER->id, true);
 


### PR DESCRIPTION
Currently is very hard to correctly translate email notifications to some other languages. The problem is that some languages has other order of words, than english, so creating message by simple contactenation of lang strings in fixed order is incorrect. Correct is to use get_string substtutions, so that translator may be able to shange order of words and substitutions. This commit fixes this problem
