### PR TITLE
Update to not throw notices during sep group mode

### DIFF
--- a/view.php
+++ b/view.php
@@ -185,6 +185,7 @@ if ($groupmode == NOGROUPS) {  //No groups mode
     echo $OUTPUT->box_end();
 
     groups_print_activity_menu($cm, $CFG->wwwroot . '/mod/bigbluebuttonbn/view.php?id=' . $bbbsession['cm']->id);
+    $groups = groups_get_activity_allowed_groups($bbbsession['cm']);
     if ($groupmode == SEPARATEGROUPS && sizeof($groups) > 0) {
         $groups = groups_get_activity_allowed_groups($bbbsession['cm']);
         $current_group = current($groups);


### PR DESCRIPTION
Different from the Blindside Networks' solution due to an edge case where a course may be in separate group mode and still have 0 groups at the time of creation and testing of BBB.