### PR TITLE
Change operator "AND" to "OR" in order to fetch several roles

### DIFF
--- a/locallib.php
+++ b/locallib.php
@@ -572,7 +572,7 @@ function bigbluebuttonbn_get_user_roles($context, $userid) {
     if ($userroles) {
         $where = '';
         foreach ($userroles as $value) {
-            $where .= (empty($where) ? ' WHERE' : ' AND').' id='.$value->roleid;
+            $where .= (empty($where) ? ' WHERE' : ' OR').' id='.$value->roleid;
         }
         $userroles = $DB->get_records_sql('SELECT * FROM {role}'.$where);
     }


### PR DESCRIPTION
When line 575 use a 'AND' operator, a user with multiple roles in the current context get 0 roles back since the criteria is not met. I think the intended result is met with the operator 'OR', so we get several roles back.