### PR TITLE
CONTRIB-7413: New feature: choose between Flash/HTML5 Web Client in each room

### DIFF
--- a/backup/moodle2/backup_bigbluebuttonbn_stepslib.php
+++ b/backup/moodle2/backup_bigbluebuttonbn_stepslib.php
@@ -51,7 +51,7 @@ class backup_bigbluebuttonbn_activity_structure_step extends backup_activity_str
                             'voicebridge', 'openingtime', 'closingtime', 'timecreated',
                             'timemodified', 'presentation', 'participants', 'userlimit',
                             'recordings_html', 'recordings_deleted', 'recordings_imported',
-                            'recordings_preview'));
+                            'recordings_preview', 'clienttype'));
 
         $logs = new backup_nested_element('logs');
 

--- a/bbb_broker.php
+++ b/bbb_broker.php
@@ -811,6 +811,8 @@ function bigbluebuttonbn_broker_required_parameters() {
 /**
  * Helper for definig default rules for validating required parameters.
  *
+ * @param string $id
+ *
  * @return array
  */
 function bigbluebuttonbn_broker_required_parameters_default($id) {

--- a/bbb_view.php
+++ b/bbb_view.php
@@ -327,7 +327,7 @@ function bigbluebutton_bbb_view_join_meeting($bbbsession, $cm, $bigbluebuttonbn)
         $password = $bbbsession['modPW'];
     }
     $joinurl = bigbluebuttonbn_get_join_url($bbbsession['meetingid'], $bbbsession['username'],
-        $password, $bbbsession['logoutURL'], null, $bbbsession['userID']);
+        $password, $bbbsession['logoutURL'], null, $bbbsession['userID'], $bbbsession['clienttype']);
     // Moodle event logger: Create an event for meeting joined.
     bigbluebuttonbn_event_log(BIGBLUEBUTTON_EVENT_MEETING_JOINED, $bigbluebuttonbn, $cm);
     // Internal logger: Instert a record with the meeting created.

--- a/classes/locallib/bigbluebutton.php
+++ b/classes/locallib/bigbluebutton.php
@@ -38,7 +38,7 @@ require_once($CFG->dirroot . '/mod/bigbluebuttonbn/locallib.php');
 class bigbluebutton {
 
     /**
-     * Performs HTTP request on the BigBlueButton server.
+     * Returns the right URL for the action specified.
      *
      * @param string $action
      * @param array  $data
@@ -80,5 +80,15 @@ class bigbluebutton {
      */
     public static function sanitized_secret() {
         return trim(\mod_bigbluebuttonbn\locallib\config::get('shared_secret'));
+    }
+
+    /**
+     * Returns the BigBlueButton server root URL.
+     *
+     * @return string
+     */
+    public static function root() {
+        $pserverurl = parse_url(trim(\mod_bigbluebuttonbn\locallib\config::get('server_url')));
+        return $pserverurl['scheme'] . "://" . $pserverurl['host'] . (isset($pserverurl['port']) ? ":" . $pserverurl['port'] : "") . "/";
     }
 }

--- a/classes/locallib/bigbluebutton.php
+++ b/classes/locallib/bigbluebutton.php
@@ -89,6 +89,10 @@ class bigbluebutton {
      */
     public static function root() {
         $pserverurl = parse_url(trim(\mod_bigbluebuttonbn\locallib\config::get('server_url')));
-        return $pserverurl['scheme'] . "://" . $pserverurl['host'] . (isset($pserverurl['port']) ? ":" . $pserverurl['port'] : "") . "/";
+        $pserverurlport = "";
+        if (isset($pserverurl['port'])) {
+            $pserverurlport = ":" . $pserverurl['port'];
+        }
+        return $pserverurl['scheme'] . "://" . $pserverurl['host'] . $pserverurlport . "/";
     }
 }

--- a/classes/locallib/config.php
+++ b/classes/locallib/config.php
@@ -57,44 +57,45 @@ class config {
         return array(
             'server_url' => (string) BIGBLUEBUTTONBN_DEFAULT_SERVER_URL,
             'shared_secret' => (string) BIGBLUEBUTTONBN_DEFAULT_SHARED_SECRET,
-            'voicebridge_editable' => 'false',
-            'importrecordings_enabled' => 'false',
-            'importrecordings_from_deleted_enabled' => 'false',
-            'waitformoderator_default' => 'false',
-            'waitformoderator_editable' => 'true',
+            'voicebridge_editable' => false,
+            'importrecordings_enabled' => false,
+            'importrecordings_from_deleted_enabled' => false,
+            'waitformoderator_default' => false,
+            'waitformoderator_editable' => true,
             'waitformoderator_ping_interval' => '10',
             'waitformoderator_cache_ttl' => '60',
             'userlimit_default' => '0',
-            'userlimit_editable' => 'false',
-            'preuploadpresentation_enabled' => 'false',
-            'sendnotifications_enabled' => 'false',
-            'recordingready_enabled' => 'false',
-            'recordingstatus_enabled' => 'false',
-            'meetingevents_enabled' => 'false',
+            'userlimit_editable' => false,
+            'preuploadpresentation_enabled' => false,
+            'sendnotifications_enabled' => false,
+            'recordingready_enabled' => false,
+            'recordingstatus_enabled' => false,
+            'meetingevents_enabled' => false,
             'participant_moderator_default' => '0',
-            'scheduled_duration_enabled' => 'false',
+            'scheduled_duration_enabled' => false,
             'scheduled_duration_compensation' => '10',
             'scheduled_pre_opening' => '10',
-            'recordings_enabled' => 'true',
-            'recordings_html_default' => 'false',
-            'recordings_html_editable' => 'false',
-            'recordings_deleted_default' => 'false',
-            'recordings_deleted_editable' => 'false',
-            'recordings_imported_default' => 'false',
-            'recordings_imported_editable' => 'false',
-            'recordings_preview_default' => 'true',
-            'recordings_preview_editable' => 'false',
-            'recording_default' => 'true',
-            'recording_editable' => 'true',
-            'recording_icons_enabled' => 'true',
+            'recordings_enabled' => true,
+            'recordings_html_default' => false,
+            'recordings_html_editable' => false,
+            'recordings_deleted_default' => false,
+            'recordings_deleted_editable' => false,
+            'recordings_imported_default' => false,
+            'recordings_imported_editable' => false,
+            'recordings_preview_default' => true,
+            'recordings_preview_editable' => false,
+            'recording_default' => true,
+            'recording_editable' => true,
+            'recording_icons_enabled' => true,
             'general_warning_message' => '',
             'general_warning_roles' => 'editingteacher,teacher',
             'general_warning_box_type' => 'info',
             'general_warning_button_text' => '',
             'general_warning_button_href' => '',
             'general_warning_button_class' => '',
+            'clienttype_enabled' => false,
             'clienttype_default' => '0',
-            'clienttype_editable' => 'true',
+            'clienttype_editable' => true,
         );
     }
 
@@ -148,6 +149,16 @@ class config {
     }
 
     /**
+     * Validates if clienttype settings are enabled.
+     *
+     * @return boolean
+     */
+    public static function clienttype_enabled() {
+        $clienttypeenabled = self::get('clienttype_enabled');
+        return (boolean)self::get('clienttype_enabled');
+    }
+
+    /**
      * Wraps current settings in an array.
      *
      * @return array
@@ -181,6 +192,7 @@ class config {
                'general_warning_button_text' => self::get('general_warning_button_text'),
                'general_warning_button_href' => self::get('general_warning_button_href'),
                'general_warning_button_class' => self::get('general_warning_button_class'),
+               'clienttype_enabled' => self::get('clienttype_enabled'),
                'clienttype_editable' => self::get('clienttype_editable'),
                'clienttype_default' => self::get('clienttype_default'),
           );

--- a/classes/locallib/config.php
+++ b/classes/locallib/config.php
@@ -93,6 +93,8 @@ class config {
             'general_warning_button_text' => '',
             'general_warning_button_href' => '',
             'general_warning_button_class' => '',
+            'clienttype_default' => '0',
+            'clienttype_editable' => 'true',
         );
     }
 
@@ -179,6 +181,8 @@ class config {
                'general_warning_button_text' => self::get('general_warning_button_text'),
                'general_warning_button_href' => self::get('general_warning_button_href'),
                'general_warning_button_class' => self::get('general_warning_button_class'),
+               'clienttype_editable' => self::get('clienttype_editable'),
+               'clienttype_default' => self::get('clienttype_default'),
           );
     }
 }

--- a/classes/settings/renderer.php
+++ b/classes/settings/renderer.php
@@ -138,6 +138,23 @@ class renderer {
     }
 
     /**
+     * Render a select element in a group.
+     *
+     * @param string    $name
+     * @param object    $defaultsetting
+     * @param object    $choices
+     *
+     * @return Object
+     */
+    public function render_group_element_configselect($name, $defaultsetting, $choices) {
+        $item = new \admin_setting_configselect('bigbluebuttonbn_' . $name,
+                get_string('config_' . $name, 'bigbluebuttonbn'),
+                get_string('config_' . $name . '_description', 'bigbluebuttonbn'),
+                $defaultsetting, $choices);
+        return $item;
+    }
+
+    /**
      * Render a general warning message.
      *
      * @param string    $name
@@ -285,6 +302,16 @@ class renderer {
     public static function section_send_notifications_shown() {
         global $CFG;
         return (!isset($CFG->bigbluebuttonbn['sendnotifications_enabled']));
+    }
+
+    /**
+     * Validate if clienttype section will be shown.
+     *
+     * @return boolean
+     */
+    public static function section_clienttype_shown() {
+        global $CFG;
+        return (!isset($CFG->bigbluebuttonbn['clienttype_enabled']));
     }
 
     /**

--- a/classes/settings/renderer.php
+++ b/classes/settings/renderer.php
@@ -311,7 +311,8 @@ class renderer {
      */
     public static function section_clienttype_shown() {
         global $CFG;
-        return (!isset($CFG->bigbluebuttonbn['clienttype_enabled']));
+        return (!isset($CFG->bigbluebuttonbn['clienttype_default']) ||
+                !isset($CFG->bigbluebuttonbn['clienttype_editable']));
     }
 
     /**

--- a/classes/settings/renderer.php
+++ b/classes/settings/renderer.php
@@ -311,6 +311,13 @@ class renderer {
      */
     public static function section_clienttype_shown() {
         global $CFG;
+        if (!isset($CFG->bigbluebuttonbn['clienttype_enabled']) ||
+            !$CFG->bigbluebuttonbn['clienttype_enabled']) {
+            return false;
+        }
+        if (!bigbluebuttonbn_has_html5_client()) {
+            return false;
+        }
         return (!isset($CFG->bigbluebuttonbn['clienttype_default']) ||
                 !isset($CFG->bigbluebuttonbn['clienttype_editable']));
     }

--- a/config-dist.php
+++ b/config-dist.php
@@ -265,11 +265,31 @@ $CFG->bigbluebuttonbn['shared_secret'] = '8cd8ef52e8e101574e400365b55e11a6';
   * $CFG->bigbluebuttonbn['recordings_preview_default'] = 1;
   */
 
-  /*
-   * When the value is set to 1 (checked) the 'preview ui' capability can be
-   * enabled/disabled by the user creating or editing the resource.
-   * $CFG->bigbluebuttonbn['recordings_preview_editable'] = 0;
-   */
+ /*
+  * When the value is set to 1 (checked) the 'preview ui' capability can be
+  * enabled/disabled by the user creating or editing the resource.
+  * $CFG->bigbluebuttonbn['recordings_preview_editable'] = 0;
+  */
+
+ /*
+  * The WebClient by default is the Flash one (value = 0) or
+  * the HTML5 one (value = 1)
+  * $CFG->bigbluebuttonbn['clienttype_default'] = 0;
+  */
+
+ /*
+  * When the value is set to 1 (checked) the 'clienttype'
+  * capability is enabled, meaning that the administrator can choose the default web client type
+  * and if can be editable in each room through the plugin configuration
+  * $CFG->bigbluebuttonbn['clienttype_enabled'] = 0;
+  */
+
+ /*
+  * When the value is set to 1 (checked) the WebClient can be chosen
+  * the user creating or editing the resource.
+  * $CFG->bigbluebuttonbn['clienttype_editable'] = 0;
+  */
+
 
 /*
  *  CONFIGURATION FOR FEATURES OFFERED BY BN SERVERS

--- a/config-dist.php
+++ b/config-dist.php
@@ -272,6 +272,13 @@ $CFG->bigbluebuttonbn['shared_secret'] = '8cd8ef52e8e101574e400365b55e11a6';
  */
 
 /*
+ * When the value is set to 1 (checked) the 'clienttype' capability is enabled,
+ * meaning that the administrator may be able to choose the default web client type
+ * and wheter it can be editable in each room through the plugin configuration
+ * $CFG->bigbluebuttonbn['clienttype_enabled'] = 0;
+ */
+
+/*
  * The WebClient selected by default is Flash (value = 0)
  * [flash=0|html5=1]
  * $CFG->bigbluebuttonbn['clienttype_default'] = 0;

--- a/config-dist.php
+++ b/config-dist.php
@@ -259,36 +259,29 @@ $CFG->bigbluebuttonbn['shared_secret'] = '8cd8ef52e8e101574e400365b55e11a6';
  * $CFG->bigbluebuttonbn['recordings_imported_editable'] = 1;
  */
 
- /*
-  * When the value is set to 1 (checked) the bigbluebuttonbn resources
-  * will show the recodings with thumbnails.
-  * $CFG->bigbluebuttonbn['recordings_preview_default'] = 1;
-  */
+/*
+ * When the value is set to 1 (checked) the bigbluebuttonbn resources
+ * will show the recodings with thumbnails.
+ * $CFG->bigbluebuttonbn['recordings_preview_default'] = 1;
+ */
 
- /*
-  * When the value is set to 1 (checked) the 'preview ui' capability can be
-  * enabled/disabled by the user creating or editing the resource.
-  * $CFG->bigbluebuttonbn['recordings_preview_editable'] = 0;
-  */
+/*
+ * When the value is set to 1 (checked) the 'preview ui' capability can be
+ * enabled/disabled by the user creating or editing the resource.
+ * $CFG->bigbluebuttonbn['recordings_preview_editable'] = 0;
+ */
 
- /*
-  * The WebClient by default is the Flash one (value = 0) or
-  * the HTML5 one (value = 1)
-  * $CFG->bigbluebuttonbn['clienttype_default'] = 0;
-  */
+/*
+ * The WebClient selected by default is Flash (value = 0)
+ * [flash=0|html5=1]
+ * $CFG->bigbluebuttonbn['clienttype_default'] = 0;
+ */
 
- /*
-  * When the value is set to 1 (checked) the 'clienttype'
-  * capability is enabled, meaning that the administrator can choose the default web client type
-  * and if can be editable in each room through the plugin configuration
-  * $CFG->bigbluebuttonbn['clienttype_enabled'] = 0;
-  */
-
- /*
-  * When the value is set to 1 (checked) the WebClient can be chosen
-  * the user creating or editing the resource.
-  * $CFG->bigbluebuttonbn['clienttype_editable'] = 0;
-  */
+/*
+ * When the value is set to 1 (checked) the WebClient can be chosen by
+ * the user creating or editing the resource.
+ * $CFG->bigbluebuttonbn['clienttype_editable'] = 0;
+ */
 
 
 /*

--- a/db/install.xml
+++ b/db/install.xml
@@ -30,6 +30,7 @@
         <FIELD NAME="recordings_deleted" TYPE="int" LENGTH="1" NOTNULL="true" UNSIGNED="false" DEFAULT="1" SEQUENCE="false"/>
         <FIELD NAME="recordings_imported" TYPE="int" LENGTH="1" NOTNULL="true" UNSIGNED="false" DEFAULT="0" SEQUENCE="false"/>
         <FIELD NAME="recordings_preview" TYPE="int" LENGTH="1" NOTNULL="true" UNSIGNED="false" DEFAULT="0" SEQUENCE="false"/>
+        <FIELD NAME="clienttype" TYPE="int" LENGTH="1" NOTNULL="true" UNSIGNED="false" DEFAULT="0" SEQUENCE="false"/>
       </FIELDS>
       <KEYS>
         <KEY NAME="primary" TYPE="primary" FIELDS="id"/>

--- a/db/upgrade.php
+++ b/db/upgrade.php
@@ -157,6 +157,15 @@ function xmldb_bigbluebuttonbn_upgrade($oldversion = 0) {
         // Update db version tag.
         upgrade_mod_savepoint(true, 2017101012, 'bigbluebuttonbn');
     }
+    if ($oldversion < 2017101015) {
+        // Add field for client technology choice.
+        $fielddefinition = array('type' => XMLDB_TYPE_INTEGER, 'precision' => '1', 'unsigned' => null,
+            'notnull' => XMLDB_NOTNULL, 'sequence' => null, 'default' => 0, 'previous' => null);
+        xmldb_bigbluebuttonbn_add_change_field($dbman, 'bigbluebuttonbn', 'clienttype',
+            $fielddefinition);
+        // Update db version tag.
+        upgrade_mod_savepoint(true, 2017101015, 'bigbluebuttonbn');
+    }
     return true;
 }
 

--- a/lang/en/bigbluebuttonbn.php
+++ b/lang/en/bigbluebuttonbn.php
@@ -397,3 +397,15 @@ $string['view_error_action_not_completed'] = 'Action could not be completed';
 $string['view_warning_default_server'] = 'This Moodle server is making use of the BigBlueButton testing server that comes pre-configured by default. It should be replaced for production.';
 
 $string['view_room'] = 'View room';
+
+$string['mod_form_block_clienttype'] = 'Web Client Technology';
+$string['mod_form_block_clienttype_flash'] = 'Client based on Adobe Flash technology';
+$string['mod_form_block_clienttype_html5'] = 'Client based on HTML5 technology';
+$string['mod_form_field_block_clienttype'] = 'Web Client Technology';
+
+$string['config_clienttype'] = 'Configuration for "Web Client" type';
+$string['config_clienttype_default'] = 'Default Web Client type';
+$string['config_clienttype_default_description'] = 'Choose between the classical Adobe Flash client or the new HTML5 one.';
+$string['config_clienttype_description'] = 'This setting enable/disable the Web Client choice for each room.';
+$string['config_clienttype_editable'] = 'The Web Client choice can be edited';
+$string['config_clienttype_editable_description'] = 'This option enable the choice of the Web Client (AdobeFlash/HTML5) from the room editing form.';

--- a/locallib.php
+++ b/locallib.php
@@ -100,7 +100,7 @@ function bigbluebuttonbn_get_join_url($meetingid, $username, $pw, $logouturl, $c
             ];
     // Choose between Adobe Flash or HTML5 Client.
     if ( $clienttype == BIGBLUEBUTTON_CLIENTTYPE_HTML5 ) {
-       $data['joinViaHtml5'] = 'true';
+        $data['joinViaHtml5'] = 'true';
     }
 
     if (!is_null($configtoken)) {

--- a/locallib.php
+++ b/locallib.php
@@ -74,6 +74,10 @@ const BIGBLUEBUTTON_EVENT_RECORDING_EDITED = 'recording_edited';
 const BIGBLUEBUTTON_EVENT_RECORDING_VIEWED = 'recording_viewed';
 /** @var BIGBLUEBUTTON_EVENT_MEETING_START string defines the bigbluebuttonbn meeting_start event */
 const BIGBLUEBUTTON_EVENT_MEETING_START = 'meeting_start';
+/** @var BIGBLUEBUTTON_CLIENTTYPE_FLASH integer that defines the bigbluebuttonbn default web client based on Adobe FLASH */
+const BIGBLUEBUTTON_CLIENTTYPE_FLASH = 0;
+/** @var BIGBLUEBUTTON_CLIENTTYPE_HTML5 integer that defines the bigbluebuttonbn default web client based on Adobe HTML5 */
+const BIGBLUEBUTTON_CLIENTTYPE_HTML5 = 1;
 
 /**
  * Builds and retunrs a url for joining a bigbluebutton meeting.
@@ -87,14 +91,14 @@ const BIGBLUEBUTTON_EVENT_MEETING_START = 'meeting_start';
  *
  * @return string
  */
-function bigbluebuttonbn_get_join_url($meetingid, $username, $pw, $logouturl, $configtoken = null, $userid = null, $clienttype=0) {
+function bigbluebuttonbn_get_join_url($meetingid, $username, $pw, $logouturl, $configtoken = null, $userid = null, $clienttype=BIGBLUEBUTTON_CLIENTTYPE_FLASH) {
     $data = ['meetingID' => $meetingid,
               'fullName' => $username,
               'password' => $pw,
               'logoutURL' => $logouturl,
             ];
     // Choose between Adobe Flash or HTML5 Client
-    if ( $clienttype == 1 ) {
+    if ( $clienttype == BIGBLUEBUTTON_CLIENTTYPE_HTML5 ) {
     	$data['joinViaHtml5'] = 'true';
     }
 
@@ -2606,7 +2610,7 @@ function bigbluebuttonbn_settings_clienttype(&$renderer) {
         $clienttype_default = intval((int)\mod_bigbluebuttonbn\locallib\config::get('clienttype_default'));
 
 	// Flash or HTML5  meeting
-        $clienttype_select_choices = array(0 => get_string('mod_form_block_clienttype_flash', 'bigbluebuttonbn'), 1 => get_string('mod_form_block_clienttype_html5', 'bigbluebuttonbn'));
+        $clienttype_select_choices = array(BIGBLUEBUTTON_CLIENTTYPE_FLASH => get_string('mod_form_block_clienttype_flash', 'bigbluebuttonbn'), BIGBLUEBUTTON_CLIENTTYPE_HTML5 => get_string('mod_form_block_clienttype_html5', 'bigbluebuttonbn'));
         $renderer->render_group_element('clienttype_default',
             $renderer->render_group_element_configselect('clienttype_default',
                 $clienttype_default, $clienttype_select_choices));

--- a/locallib.php
+++ b/locallib.php
@@ -92,7 +92,7 @@ const BIGBLUEBUTTON_CLIENTTYPE_HTML5 = 1;
  * @return string
  */
 function bigbluebuttonbn_get_join_url($meetingid, $username, $pw, $logouturl, $configtoken = null,
-                                      $userid = null, $clienttype=BIGBLUEBUTTON_CLIENTTYPE_FLASH) {
+                                      $userid = null, $clienttype = BIGBLUEBUTTON_CLIENTTYPE_FLASH) {
     $data = ['meetingID' => $meetingid,
               'fullName' => $username,
               'password' => $pw,

--- a/locallib.php
+++ b/locallib.php
@@ -91,13 +91,14 @@ const BIGBLUEBUTTON_CLIENTTYPE_HTML5 = 1;
  *
  * @return string
  */
-function bigbluebuttonbn_get_join_url($meetingid, $username, $pw, $logouturl, $configtoken = null, $userid = null, $clienttype=BIGBLUEBUTTON_CLIENTTYPE_FLASH) {
+function bigbluebuttonbn_get_join_url($meetingid, $username, $pw, $logouturl, $configtoken = null,
+                                      $userid = null, $clienttype=BIGBLUEBUTTON_CLIENTTYPE_FLASH) {
     $data = ['meetingID' => $meetingid,
               'fullName' => $username,
               'password' => $pw,
               'logoutURL' => $logouturl,
             ];
-    // Choose between Adobe Flash or HTML5 Client
+    // Choose between Adobe Flash or HTML5 Client.
     if ( $clienttype == BIGBLUEBUTTON_CLIENTTYPE_HTML5 ) {
     	$data['joinViaHtml5'] = 'true';
     }
@@ -2606,14 +2607,16 @@ function bigbluebuttonbn_settings_clienttype(&$renderer) {
         $renderer->render_group_element('clienttype_editable',
             $renderer->render_group_element_checkbox('clienttype_editable', 1));
 
-        // Web Client default
-        $clienttype_default = intval((int)\mod_bigbluebuttonbn\locallib\config::get('clienttype_default'));
+        // Web Client default.
+        $default = intval((int)\mod_bigbluebuttonbn\locallib\config::get('clienttype_default'));
 
-	// Flash or HTML5  meeting
-        $clienttype_select_choices = array(BIGBLUEBUTTON_CLIENTTYPE_FLASH => get_string('mod_form_block_clienttype_flash', 'bigbluebuttonbn'), BIGBLUEBUTTON_CLIENTTYPE_HTML5 => get_string('mod_form_block_clienttype_html5', 'bigbluebuttonbn'));
+        $choices = array(BIGBLUEBUTTON_CLIENTTYPE_FLASH =>
+                            get_string('mod_form_block_clienttype_flash', 'bigbluebuttonbn'),
+                         BIGBLUEBUTTON_CLIENTTYPE_HTML5 => 
+                            get_string('mod_form_block_clienttype_html5', 'bigbluebuttonbn'));
         $renderer->render_group_element('clienttype_default',
             $renderer->render_group_element_configselect('clienttype_default',
-                $clienttype_default, $clienttype_select_choices));
+                $default, $choices));
     }
 }
 

--- a/locallib.php
+++ b/locallib.php
@@ -2605,7 +2605,7 @@ function bigbluebuttonbn_settings_clienttype(&$renderer) {
     if ((boolean)\mod_bigbluebuttonbn\settings\renderer::section_clienttype_shown()) {
         $renderer->render_group_header('clienttype');
         $renderer->render_group_element('clienttype_editable',
-            $renderer->render_group_element_checkbox('clienttype_editable', 1));
+            $renderer->render_group_element_checkbox('clienttype_editable', 0));
 
         // Web Client default.
         $default = intval((int)\mod_bigbluebuttonbn\locallib\config::get('clienttype_default'));

--- a/locallib.php
+++ b/locallib.php
@@ -100,7 +100,7 @@ function bigbluebuttonbn_get_join_url($meetingid, $username, $pw, $logouturl, $c
             ];
     // Choose between Adobe Flash or HTML5 Client.
     if ( $clienttype == BIGBLUEBUTTON_CLIENTTYPE_HTML5 ) {
-    	$data['joinViaHtml5'] = 'true';
+       $data['joinViaHtml5'] = 'true';
     }
 
     if (!is_null($configtoken)) {
@@ -2610,10 +2610,8 @@ function bigbluebuttonbn_settings_clienttype(&$renderer) {
         // Web Client default.
         $default = intval((int)\mod_bigbluebuttonbn\locallib\config::get('clienttype_default'));
 
-        $choices = array(BIGBLUEBUTTON_CLIENTTYPE_FLASH =>
-                            get_string('mod_form_block_clienttype_flash', 'bigbluebuttonbn'),
-                         BIGBLUEBUTTON_CLIENTTYPE_HTML5 => 
-                            get_string('mod_form_block_clienttype_html5', 'bigbluebuttonbn'));
+        $choices = array(BIGBLUEBUTTON_CLIENTTYPE_FLASH => get_string('mod_form_block_clienttype_flash', 'bigbluebuttonbn'),
+                         BIGBLUEBUTTON_CLIENTTYPE_HTML5 => get_string('mod_form_block_clienttype_html5', 'bigbluebuttonbn'));
         $renderer->render_group_element('clienttype_default',
             $renderer->render_group_element_configselect('clienttype_default',
                 $default, $choices));

--- a/locallib.php
+++ b/locallib.php
@@ -87,12 +87,17 @@ const BIGBLUEBUTTON_EVENT_MEETING_START = 'meeting_start';
  *
  * @return string
  */
-function bigbluebuttonbn_get_join_url($meetingid, $username, $pw, $logouturl, $configtoken = null, $userid = null) {
+function bigbluebuttonbn_get_join_url($meetingid, $username, $pw, $logouturl, $configtoken = null, $userid = null, $clienttype=0) {
     $data = ['meetingID' => $meetingid,
               'fullName' => $username,
               'password' => $pw,
               'logoutURL' => $logouturl,
             ];
+    // Choose between Adobe Flash or HTML5 Client
+    if ( $clienttype == 1 ) {
+    	$data['joinViaHtml5'] = 'true';
+    }
+
     if (!is_null($configtoken)) {
         $data['configToken'] = $configtoken;
     }
@@ -2580,6 +2585,31 @@ function bigbluebuttonbn_settings_notifications(&$renderer) {
         $renderer->render_group_header('sendnotifications');
         $renderer->render_group_element('sendnotifications_enabled',
             $renderer->render_group_element_checkbox('sendnotifications_enabled', 1));
+    }
+}
+
+/**
+ * Helper function renders client type settings if the feature is enabled.
+ *
+ * @param object $renderer
+ *
+ * @return void
+ */
+function bigbluebuttonbn_settings_clienttype(&$renderer) {
+    // Configuration for "clienttype" feature.
+    if ((boolean)\mod_bigbluebuttonbn\settings\renderer::section_clienttype_shown()) {
+        $renderer->render_group_header('clienttype');
+        $renderer->render_group_element('clienttype_editable',
+            $renderer->render_group_element_checkbox('clienttype_editable', 1));
+
+        // Web Client default
+        $clienttype_default = intval((int)\mod_bigbluebuttonbn\locallib\config::get('clienttype_default'));
+
+	// Flash or HTML5  meeting
+        $clienttype_select_choices = array(0 => get_string('mod_form_block_clienttype_flash', 'bigbluebuttonbn'), 1 => get_string('mod_form_block_clienttype_html5', 'bigbluebuttonbn'));
+        $renderer->render_group_element('clienttype_default',
+            $renderer->render_group_element_configselect('clienttype_default',
+                $clienttype_default, $clienttype_select_choices));
     }
 }
 

--- a/locallib.php
+++ b/locallib.php
@@ -2204,7 +2204,7 @@ function bigbluebuttonbn_get_instance_type_profiles() {
             array('id' => BIGBLUEBUTTONBN_TYPE_ROOM_ONLY, 'name' => get_string('instance_type_room_only', 'bigbluebuttonbn'),
                 'features' => array('showroom', 'welcomemessage', 'voicebridge', 'waitformoderator', 'userlimit', 'recording',
                     'sendnotifications', 'preuploadpresentation', 'permissions', 'schedule', 'groups',
-                    'modstandardelshdr', 'availabilityconditionsheader', 'tagshdr', 'competenciessection')),
+                    'modstandardelshdr', 'availabilityconditionsheader', 'tagshdr', 'competenciessection', 'clienttype')),
             array('id' => BIGBLUEBUTTONBN_TYPE_RECORDING_ONLY, 'name' => get_string('instance_type_recording_only',
                 'bigbluebuttonbn'), 'features' => array('showrecordings', 'importrecordings')),
     );
@@ -2234,6 +2234,11 @@ function bigbluebuttonbn_get_enabled_features($typeprofiles, $type = null) {
     $enabledfeatures['importrecordings'] = false;
     if (\mod_bigbluebuttonbn\locallib\config::importrecordings_enabled()) {
         $enabledfeatures['importrecordings'] = (in_array('all', $features) || in_array('importrecordings', $features));
+    }
+    // Evaluates if clienttype is enabled for the Moodle site.
+    $enabledfeatures['clienttype'] = false;
+    if (\mod_bigbluebuttonbn\locallib\config::clienttype_enabled()) {
+        $enabledfeatures['clienttype'] = (in_array('all', $features) || in_array('clienttype', $features));
     }
     return $enabledfeatures;
 }
@@ -2866,4 +2871,15 @@ function bigbluebuttonbn_instance_ownerid($bigbluebuttonbn) {
     $filters = array('bigbluebuttonbnid' => $bigbluebuttonbn->id, 'log' => 'Add');
     $ownerid = (integer)$DB->get_field('bigbluebuttonbn_logs', 'userid', $filters);
     return $ownerid;
+}
+
+/**
+ * Helper evaluates if the bigbluebutton server used belongs to blindsidenetworks domain.
+ *
+ * @return boolean
+ */
+function bigbluebuttonbn_has_html5_client() {
+    $checkurl = \mod_bigbluebuttonbn\locallib\bigbluebutton::root() . "html5client/check";
+    $curlinfo = bigbluebuttonbn_wrap_xml_load_file_curl_request($checkurl, 'HEAD');
+    return (isset($curlinfo['http_code']) && $curlinfo['http_code'] == 200);
 }

--- a/mod_form.php
+++ b/mod_form.php
@@ -392,16 +392,18 @@ class mod_bigbluebuttonbn_mod_form extends moodleform_mod {
             $field['data_type'] = PARAM_TEXT;
             $field['description_key'] = 'mod_form_field_block_clienttype';
 
-            // Flash or HTML5  meeting
-            $clienttype_select_choices = array(BIGBLUEBUTTON_CLIENTTYPE_FLASH => get_string('mod_form_block_clienttype_flash', 'bigbluebuttonbn'), BIGBLUEBUTTON_CLIENTTYPE_HTML5 => get_string('mod_form_block_clienttype_html5', 'bigbluebuttonbn'));
+            $choices = array(BIGBLUEBUTTON_CLIENTTYPE_FLASH => 
+                        get_string('mod_form_block_clienttype_flash', 'bigbluebuttonbn'),
+                             BIGBLUEBUTTON_CLIENTTYPE_HTML5 => 
+                        get_string('mod_form_block_clienttype_html5', 'bigbluebuttonbn'));
 
             $mform->addElement('header', 'clienttypeselection', get_string('mod_form_block_clienttype', 'bigbluebuttonbn'));
             $this->bigbluebuttonbn_mform_add_element($mform, $field['type'], $field['name'], $field['data_type'],
-                $field['description_key'], $cfg['clienttype_default'] ,$clienttype_select_choices);
+                                    $field['description_key'], $cfg['clienttype_default'], $choices);
         } else {
-            $this->bigbluebuttonbn_mform_add_element($mform, $field['type'], $field['name'], $field['data_type'], null,$cfg['clienttype_default']);
-	}
-
+            $this->bigbluebuttonbn_mform_add_element($mform, $field['type'], $field['name'], $field['data_type'],
+                                    null, $cfg['clienttype_default']);
+        }
     }
 
     /**

--- a/mod_form.php
+++ b/mod_form.php
@@ -69,6 +69,7 @@ class mod_bigbluebuttonbn_mod_form extends moodleform_mod {
         $context = context_course::instance($course->id);
         // UI configuration options.
         $cfg = \mod_bigbluebuttonbn\locallib\config::get_options();
+error_log("RABSER DEBUG ".print_r($cfg,true));
         $mform = &$this->_form;
         $jsvars = array();
         $jsvars['instanceTypeRoomOnly'] = BIGBLUEBUTTONBN_TYPE_ROOM_ONLY;
@@ -86,6 +87,8 @@ class mod_bigbluebuttonbn_mod_form extends moodleform_mod {
         $this->bigbluebuttonbn_mform_add_block_participants($mform, $cfg, $participantlist);
         // Add block 'Schedule'.
         $this->bigbluebuttonbn_mform_add_block_schedule($mform, $this->current);
+        // Add block 'client Type'.
+        $this->bigbluebuttonbn_mform_add_block_clienttype($mform, $cfg);
         // Add standard elements, common to all modules.
         $this->standard_coursemodule_elements();
         // Add standard buttons, common to all modules.
@@ -373,6 +376,33 @@ class mod_bigbluebuttonbn_mod_form extends moodleform_mod {
         $mform->addElement('static', 'static_participant_list',
             get_string('mod_form_field_participant_list', 'bigbluebuttonbn'), $htmlparticipantlist);
         $mform->addElement('html', "\n\n");
+    }
+
+    /**
+     * Function for showing the client type
+     *
+     * @param object $mform
+     * @param object $cfg
+     * @return void
+     */
+    private function bigbluebuttonbn_mform_add_block_clienttype(&$mform, &$cfg) {
+        $field = ['type' => 'hidden', 'name' => 'clienttype', 'data_type' => PARAM_INT,
+            'description_key' => null];
+        if ($cfg['clienttype_editable']) {
+            $field['type'] = 'select';
+            $field['data_type'] = PARAM_TEXT;
+            $field['description_key'] = 'mod_form_field_block_clienttype';
+
+            // Flash or HTML5  meeting
+            $clienttype_select_choices = array(0 => get_string('mod_form_block_clienttype_flash', 'bigbluebuttonbn'), 1 => get_string('mod_form_block_clienttype_html5', 'bigbluebuttonbn'));
+
+            $mform->addElement('header', 'clienttypeselection', get_string('mod_form_block_clienttype', 'bigbluebuttonbn'));
+            $this->bigbluebuttonbn_mform_add_element($mform, $field['type'], $field['name'], $field['data_type'],
+                $field['description_key'], $cfg['clienttype_default'] ,$clienttype_select_choices);
+        } else {
+            $this->bigbluebuttonbn_mform_add_element($mform, $field['type'], $field['name'], $field['data_type'], null,$cfg['clienttype_default']);
+	}
+
     }
 
     /**

--- a/mod_form.php
+++ b/mod_form.php
@@ -69,7 +69,6 @@ class mod_bigbluebuttonbn_mod_form extends moodleform_mod {
         $context = context_course::instance($course->id);
         // UI configuration options.
         $cfg = \mod_bigbluebuttonbn\locallib\config::get_options();
-error_log("RABSER DEBUG ".print_r($cfg,true));
         $mform = &$this->_form;
         $jsvars = array();
         $jsvars['instanceTypeRoomOnly'] = BIGBLUEBUTTONBN_TYPE_ROOM_ONLY;
@@ -394,7 +393,7 @@ error_log("RABSER DEBUG ".print_r($cfg,true));
             $field['description_key'] = 'mod_form_field_block_clienttype';
 
             // Flash or HTML5  meeting
-            $clienttype_select_choices = array(0 => get_string('mod_form_block_clienttype_flash', 'bigbluebuttonbn'), 1 => get_string('mod_form_block_clienttype_html5', 'bigbluebuttonbn'));
+            $clienttype_select_choices = array(BIGBLUEBUTTON_CLIENTTYPE_FLASH => get_string('mod_form_block_clienttype_flash', 'bigbluebuttonbn'), BIGBLUEBUTTON_CLIENTTYPE_HTML5 => get_string('mod_form_block_clienttype_html5', 'bigbluebuttonbn'));
 
             $mform->addElement('header', 'clienttypeselection', get_string('mod_form_block_clienttype', 'bigbluebuttonbn'));
             $this->bigbluebuttonbn_mform_add_element($mform, $field['type'], $field['name'], $field['data_type'],

--- a/mod_form.php
+++ b/mod_form.php
@@ -385,6 +385,14 @@ class mod_bigbluebuttonbn_mod_form extends moodleform_mod {
      * @return void
      */
     private function bigbluebuttonbn_mform_add_block_clienttype(&$mform, &$cfg) {
+        // Validates if clienttype capability is enabled.
+        if (!$cfg['clienttype_enabled']) {
+            return;
+        }
+        // Validates if the html5client is supported by the BigBlueButton Server.
+        if (!bigbluebuttonbn_has_html5_client()) {
+            return;
+        }
         $field = ['type' => 'hidden', 'name' => 'clienttype', 'data_type' => PARAM_INT,
             'description_key' => null];
         if ($cfg['clienttype_editable']) {
@@ -398,10 +406,10 @@ class mod_bigbluebuttonbn_mod_form extends moodleform_mod {
             $mform->addElement('header', 'clienttypeselection', get_string('mod_form_block_clienttype', 'bigbluebuttonbn'));
             $this->bigbluebuttonbn_mform_add_element($mform, $field['type'], $field['name'], $field['data_type'],
                                     $field['description_key'], $cfg['clienttype_default'], $choices);
-        } else {
-            $this->bigbluebuttonbn_mform_add_element($mform, $field['type'], $field['name'], $field['data_type'],
-                                    null, $cfg['clienttype_default']);
+            return;
         }
+        $this->bigbluebuttonbn_mform_add_element($mform, $field['type'], $field['name'], $field['data_type'],
+                                null, $cfg['clienttype_default']);
     }
 
     /**

--- a/mod_form.php
+++ b/mod_form.php
@@ -392,10 +392,8 @@ class mod_bigbluebuttonbn_mod_form extends moodleform_mod {
             $field['data_type'] = PARAM_TEXT;
             $field['description_key'] = 'mod_form_field_block_clienttype';
 
-            $choices = array(BIGBLUEBUTTON_CLIENTTYPE_FLASH => 
-                        get_string('mod_form_block_clienttype_flash', 'bigbluebuttonbn'),
-                             BIGBLUEBUTTON_CLIENTTYPE_HTML5 => 
-                        get_string('mod_form_block_clienttype_html5', 'bigbluebuttonbn'));
+            $choices = array(BIGBLUEBUTTON_CLIENTTYPE_FLASH => get_string('mod_form_block_clienttype_flash', 'bigbluebuttonbn'),
+                             BIGBLUEBUTTON_CLIENTTYPE_HTML5 => get_string('mod_form_block_clienttype_html5', 'bigbluebuttonbn'));
 
             $mform->addElement('header', 'clienttypeselection', get_string('mod_form_block_clienttype', 'bigbluebuttonbn'));
             $this->bigbluebuttonbn_mform_add_element($mform, $field['type'], $field['name'], $field['data_type'],

--- a/settings.php
+++ b/settings.php
@@ -54,6 +54,7 @@ if ($ADMIN->fulltree) {
     bigbluebuttonbn_settings_duration($renderer);
     bigbluebuttonbn_settings_participants($renderer);
     bigbluebuttonbn_settings_notifications($renderer);
+    bigbluebuttonbn_settings_clienttype($renderer);
     // Renders settings for extended capabilities.
     bigbluebuttonbn_settings_extended($renderer);
 }

--- a/version.php
+++ b/version.php
@@ -26,7 +26,7 @@
 
 defined('MOODLE_INTERNAL') || die;
 
-$plugin->version = 2017101015;
+$plugin->version = 2017101014;
 $plugin->requires = 2015111610;
 $plugin->cron = 0;
 $plugin->component = 'mod_bigbluebuttonbn';

--- a/version.php
+++ b/version.php
@@ -26,7 +26,7 @@
 
 defined('MOODLE_INTERNAL') || die;
 
-$plugin->version = 2017101014;
+$plugin->version = 2017101015;
 $plugin->requires = 2015111610;
 $plugin->cron = 0;
 $plugin->component = 'mod_bigbluebuttonbn';

--- a/view.php
+++ b/view.php
@@ -185,6 +185,7 @@ function bigbluebuttonbn_view_bbbsession_set($context, &$bbbsession) {
     $bbbsession['originServerCommonName'] = '';
     $bbbsession['originTag'] = 'moodle-mod_bigbluebuttonbn ('.get_config('mod_bigbluebuttonbn', 'version').')';
     $bbbsession['bnserver'] = bigbluebuttonbn_is_bn_server();
+    $bbbsession['clienttype'] = $bbbsession['bigbluebuttonbn']->clienttype;
 }
 
 /**

--- a/view.php
+++ b/view.php
@@ -185,7 +185,14 @@ function bigbluebuttonbn_view_bbbsession_set($context, &$bbbsession) {
     $bbbsession['originServerCommonName'] = '';
     $bbbsession['originTag'] = 'moodle-mod_bigbluebuttonbn ('.get_config('mod_bigbluebuttonbn', 'version').')';
     $bbbsession['bnserver'] = bigbluebuttonbn_is_bn_server();
-    $bbbsession['clienttype'] = $bbbsession['bigbluebuttonbn']->clienttype;
+    // Setting for clienttype, assign flash if not enabled, or default if not editable.
+    $bbbsession['clienttype'] = \mod_bigbluebuttonbn\locallib\config::get('clienttype_default');
+    if (\mod_bigbluebuttonbn\locallib\config::get('clienttype_editable')) {
+        $bbbsession['clienttype'] = $bbbsession['bigbluebuttonbn']->clienttype;
+    }
+    if (!\mod_bigbluebuttonbn\locallib\config::clienttype_enabled()) {
+        $bbbsession['clienttype'] = BIGBLUEBUTTON_CLIENTTYPE_FLASH;
+    }
 }
 
 /**


### PR DESCRIPTION
As per your previous request, i did this pull request for letting you evaluate my changes for coding this new feature. I tried to follow your coding philosophy, so most of the changes to the code were done for a "correct" integration of the new setting, enabling/disabling it and it's default.
The semantic section is around the join API, were i added the joinViaHTML5 with value true if requested a define time of each single room.
The BBB server should be configured to serve the HTML5 client, but without forcing it. If the HTML5client is not installed, this option it's simply ignored.
