### PR TITLE
Incorrect pattern for config.php in .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,7 @@
 .buildpath
 .project
 .settings*
-config.php
+/config.php
 deploy*
 vendor*
 moodle-plugin-ci/


### PR DESCRIPTION
config.php shouldn't be omitted from all the repository, just the file at root directory. This is causing "classes/locallib/config.php" not being version-controlled if it's removed and added again, or new "config.php" files inside subdirectories.