### PR TITLE
Fix for reviewing JWT existence.

### DIFF
--- a/lib.php
+++ b/lib.php
@@ -40,7 +40,8 @@ require_once($CFG->libdir.'/filelib.php');
 require_once($CFG->libdir.'/formslib.php');
 
 
-if (file_exists(dirname(__FILE__).'/vendor/firebase/php-jwt/src/JWT.php')) {
+if (!class_exists('\Firebase\JWT\JWT') &&
+    file_exists(dirname(__FILE__).'/vendor/firebase/php-jwt/src/JWT.php')) {
     require_once(dirname(__FILE__).'/vendor/firebase/php-jwt/src/JWT.php');
 }
 


### PR DESCRIPTION
When other Moodle plugins are declaring or using JWT, we are getting an issue with the plugin when navigating to admin pages.
```
Fatal error: Cannot declare class Firebase\JWT\JWT, because the name is already in use in /mnt/code/www/moodle_sand/mod/bigbluebuttonbn/vendor/firebase/php-jwt/src/JWT.php on line 22
```
And a 500 server error. This will look for the JWT class before loading it.