### PR TITLE
Fix notification messages send in FOMAT_MOODLE instead of FORMAT_HTML.

### DIFF
--- a/classes/locallib/notifier.php
+++ b/classes/locallib/notifier.php
@@ -118,7 +118,7 @@ class notifier {
         $users = (array) get_enrolled_users($context, '', 0, 'u.*', null, 0, 0, true);
         foreach ($users as $user) {
             if ($user->id != $sender->id) {
-                message_post_message($sender, $user, $message, FORMAT_MOODLE);
+                message_post_message($sender, $user, $message, FORMAT_HTML);
             }
         }
     }


### PR DESCRIPTION
Hi!
It seems that a minor bug is preventing the notification messages to be send in HTML. What's rather odd is that this is fixed in `master`.
Well, here it is. Thanks for your work.
Regards.