### PR TITLE
CONTRIB-7875: Fix Call to undefined function bigbluebuttonbn_random_password()

### DIFF
--- a/lib.php
+++ b/lib.php
@@ -565,6 +565,7 @@ function bigbluebuttonbn_process_pre_save(&$bigbluebuttonbn) {
  * @return void
  **/
 function bigbluebuttonbn_process_pre_save_instance(&$bigbluebuttonbn) {
+    require_once(__DIR__.'/locallib.php');
     $bigbluebuttonbn->timemodified = time();
     if ((integer)$bigbluebuttonbn->instance == 0) {
         $bigbluebuttonbn->timecreated = time();


### PR DESCRIPTION
Hi everyone,

We are getting this unit test failure on v2.2 stable. Could you please help fix this? 
I've created a pull request to require the locallib that's needed for this function call

`bigbluebuttonbn_random_password()`

https://github.com/blindsidenetworks/moodle-mod_bigbluebuttonbn/issues/127

Thanks