### PR TITLE
CONTRIB-7960: Add the Restrict Access setting back for "Recording Onl…

### DIFF
--- a/locallib.php
+++ b/locallib.php
@@ -2453,10 +2453,10 @@ function bigbluebuttonbn_get_instance_type_profiles() {
             'features' => array('showroom', 'welcomemessage', 'voicebridge', 'waitformoderator', 'userlimit',
                 'recording', 'sendnotifications', 'preuploadpresentation', 'permissions', 'schedule', 'groups',
                 'modstandardelshdr', 'availabilityconditionsheader', 'tagshdr', 'competenciessection',
-                'clienttype', 'completionattendance', 'completionengagement')),
+                'clienttype', 'completionattendance', 'completionengagement', 'availabilityconditionsheader')),
         BIGBLUEBUTTONBN_TYPE_RECORDING_ONLY => array('id' => BIGBLUEBUTTONBN_TYPE_RECORDING_ONLY,
             'name' => get_string('instance_type_recording_only', 'bigbluebuttonbn'),
-            'features' => array('showrecordings', 'importrecordings')),
+            'features' => array('showrecordings', 'importrecordings', 'availabilityconditionsheader')),
     );
     return $instanceprofiles;
 }

--- a/tests/behat/add_instance.feature
+++ b/tests/behat/add_instance.feature
@@ -1,4 +1,4 @@
-@mod @mod_bigbluebuttonbn @rr
+@mod @mod_bigbluebuttonbn @core_form
 Feature: bigbluebuttonbn instance
   In order to create a room activity with recordings
   As a user
@@ -41,3 +41,23 @@ Feature: bigbluebuttonbn instance
     And "#bigbluebuttonbn_view_message_box" "css_element" should not be visible
     And "#bigbluebuttonbn_view_action_button_box" "css_element" should not be visible
     And "#bigbluebuttonbn_recordings_table" "css_element" should be visible
+
+  @javascript
+  Scenario: Add an activity and check that required settings are available for the three
+    types of instance types
+    When I log in as "admin"
+    And I create a course with:
+      | Course full name | Test Course |
+      | Course short name | testcourse |
+    And I follow "Test Course"
+    And I turn editing mode on
+    And I add a "BigBlueButtonBN" to section "1"
+    And I wait until the page is ready
+    When  I select "Room/Activity with recordings" from the "Instance type" singleselect
+    Then I should see "Restrict access"
+    When  I select "Room/Activity only" from the "Instance type" singleselect
+    Then I wait until the page is ready
+    Then I should see "Restrict access"
+    When  I select "Recordings only" from the "Instance type" singleselect
+    Then I wait until the page is ready
+    Then I should see "Restrict access"


### PR DESCRIPTION
I have added the availabilityconditionsheader to both BIGBLUEBUTTONBN_TYPE_ROOM_ONLY and BIGBLUEBUTTONBN_TYPE_RECORDING_ONLY. I am wondering if we should not also add "modstandardelshdr" to BIGBLUEBUTTONBN_TYPE_ROOM_ONLY and BIGBLUEBUTTONBN_TYPE_RECORDING_ONLY.

Modified the behat tests accordingly