### PR TITLE
CONTRIB-7972 and CONTRIB-7973 In the participant menu of the activity, make sure that …

### DIFF
--- a/mod_form.php
+++ b/mod_form.php
@@ -104,7 +104,7 @@ class mod_bigbluebuttonbn_mod_form extends moodleform_mod {
         $this->add_action_buttons();
         // JavaScript for locales.
         $PAGE->requires->strings_for_js(array_keys(bigbluebuttonbn_get_strings_for_js()), 'bigbluebuttonbn');
-        $jsvars['participantData'] = bigbluebuttonbn_get_participant_data($context);
+        $jsvars['participantData'] = bigbluebuttonbn_get_participant_data($context, $bigbluebuttonbn);
         $jsvars['participantList'] = $participantlist;
         $jsvars['iconsEnabled'] = (boolean)$cfg['recording_icons_enabled'];
         $jsvars['pixIconDelete'] = (string)$OUTPUT->pix_icon('t/delete', get_string('delete'), 'moodle');

--- a/tests/behat/group_mode.feature
+++ b/tests/behat/group_mode.feature
@@ -1,0 +1,90 @@
+@mod @mod_bigbluebuttonbn @course
+Feature: Test the module in group mode.
+
+  Background:
+    Given the following "courses" exist:
+      | fullname      | shortname | category | groupmode | groupmodeforce |
+      | Test Course 1 | C1        | 0        | 1         | 1              |
+    # 1 = separate groups, we force the group
+    And the following "users" exist:
+      | username | firstname | lastname | email                |
+      | teacher1 | TeacherG1 | 1        | teacher1@example.com |
+      | teacher2 | TeacherG2 | 2        | teacher2@example.com |
+      | user1    | UserG1    | 1        | user1@example.com    |
+      | user2    | UserG1    | 2        | user2@example.com    |
+      | user3    | UserG2    | 3        | user3@example.com    |
+      | user4    | UserG2    | 4        | user4@example.com    |
+      | user5    | UserG2    | 5        | user5@example.com    |
+    And the following "course enrolments" exist:
+      | user     | course | role           |
+      | teacher1 | C1     | editingteacher |
+      | teacher2 | C1     | editingteacher |
+      | user1    | C1     | student        |
+      | user2    | C1     | student        |
+      | user3    | C1     | student        |
+      | user4    | C1     | student        |
+      | user5    | C1     | student        |
+    And the following "groups" exist:
+      | name    | course | idnumber |
+      | Group 1 | C1     | G1       |
+      | Group 2 | C1     | G2       |
+    And the following "group members" exist:
+      | user     | group |
+      | teacher1 | G1    |
+      | teacher2 | G2    |
+      | user1    | G1    |
+      | user2    | G1    |
+      | user3    | G2    |
+      | user4    | G2    |
+      | user5    | G2    |
+    And the following "activities" exist:
+      | activity        | name           | intro                           | course | idnumber         | type | recordings_imported |
+      | bigbluebuttonbn | RoomRecordings | Test Room Recording description | C1     | bigbluebuttonbn1 | 0    | 0                   |
+
+  @javascript
+  Scenario: When I create a BBB activity as a teacher who cannot acces all groups,
+  I should only be able to select the group I belong on the main bigblue button page.
+    Given the following "permission overrides" exist:
+      | capability                  | permission | role           | contextlevel | reference |
+      | moodle/site:accessallgroups | Prevent    | editingteacher | Course       | C1        |
+    And I log in as "teacher1"
+    And I am on "Test Course 1" course homepage
+    Then I follow "RoomRecordings"
+    And I should see "Separate groups: Group 1"
+
+  @javascript
+  Scenario: When I create a BBB activity as a teacher, I should only be able to specify individual "User" participants
+  with whom I share a group with (or can view on the course participants screen).
+    And I log in as "teacher1"
+    And I am on "Test Course 1" course homepage
+    Then I follow "RoomRecordings"
+    And I should see "Group 1" in the "select[name='group']" "css_element"
+    And I should see "Group 2" in the "select[name='group']" "css_element"
+
+  @javascript
+  Scenario: When I create a BBB activity as a teacher, I should only be able to specify individual "User" participants
+  with whom I share a group with (or can view on the course participants screen).
+    Given the following "permission overrides" exist:
+      | capability                  | permission | role           | contextlevel | reference |
+      | moodle/site:accessallgroups | Prevent    | editingteacher | Course       | C1        |
+    And I log in as "teacher1"
+    And I am on "Test Course 1" course homepage with editing mode on
+    And I open "RoomRecordings" actions menu
+    And I click on "Edit settings" "link" in the "RoomRecordings" activity
+    Then I select "User" from the "bigbluebuttonbn_participant_selection_type" singleselect
+    And I should see "TeacherG1 1" in the "#bigbluebuttonbn_participant_selection" "css_element"
+    And I should see "UserG1 1" in the "#bigbluebuttonbn_participant_selection" "css_element"
+    And I should not see "UserG2 3" in the "#bigbluebuttonbn_participant_selection" "css_element"
+    And I should not see "TeacherG2 2" in the "#bigbluebuttonbn_participant_selection" "css_element"
+
+  @javascript
+  Scenario: When I create a BBB activity as a teacher, I should only be able to specify individual "User" participants
+  with whom I share a group with (or can view on the course participants screen).
+    And I log in as "teacher1"
+    And I am on "Test Course 1" course homepage with editing mode on
+    And I open "RoomRecordings" actions menu
+    And I click on "Edit settings" "link" in the "RoomRecordings" activity
+    Then I select "User" from the "bigbluebuttonbn_participant_selection_type" singleselect
+    And I should see "TeacherG1 1" in the "#bigbluebuttonbn_participant_selection" "css_element"
+    And I should see "UserG1 1" in the "#bigbluebuttonbn_participant_selection" "css_element"
+    And I should see "UserG2 3" in the "#bigbluebuttonbn_participant_selection" "css_element"

--- a/tests/locallib_test.php
+++ b/tests/locallib_test.php
@@ -59,4 +59,109 @@ class mod_bigbluebuttonbn_locallib_testcase extends advanced_testcase {
         $this->assertEquals('Whatever', bigbluebuttonbn_get_recording_type_text('whatever'));
         $this->assertEquals('Whatever It Can Be', bigbluebuttonbn_get_recording_type_text('whatever it can be'));
     }
+
+    public function test_bigbluebuttonbn_get_users_select_separate_groups_prevent_all() {
+        $this->resetAfterTest();
+        $numstudents = 12;
+        $numteachers = 3;
+        $groupsnum = 3;
+
+        list($course, $groups, $students, $teachers, $bbactivity, $roleids) =
+                $this->setup_course_students_teachers(
+                        ['enablecompletion' => true, 'groupmode' => strval(SEPARATEGROUPS), 'groupmodeforce' => 1],
+                        $numstudents, $numteachers, $groupsnum);
+        $context = context_course::instance($course->id);
+        // Prevent access all groups.
+        role_change_permission($roleids['teacher'], $context, 'moodle/site:accessallgroups', CAP_PREVENT);
+        $this->setUser($teachers[0]);
+        $users = bigbluebuttonbn_get_users_select($context, $bbactivity);
+        $this->assertCount(($numstudents + $numteachers) / $groupsnum, $users);
+        $this->setUser($teachers[1]);
+        $users = bigbluebuttonbn_get_users_select($context, $bbactivity);
+        $this->assertCount(($numstudents + $numteachers) / $groupsnum, $users);
+        $this->setUser($teachers[2]);
+        $users = bigbluebuttonbn_get_users_select($context, $bbactivity);
+        $this->assertCount(($numstudents + $numteachers) / $groupsnum, $users);
+        $course->groupmode = strval(SEPARATEGROUPS);
+        $course->groupmodeforce = "0";
+        update_course($course);
+        $this->setUser($teachers[2]);
+        $users = bigbluebuttonbn_get_users_select($context, $bbactivity);
+        $this->assertCount($numstudents + $numteachers, $users);
+
+    }
+
+    public function test_bigbluebuttonbn_get_users_select_separate_groups() {
+        $this->resetAfterTest();
+        $numstudents = 12;
+        $numteachers = 3;
+        $groupsnum = 3;
+        list($course, $groups, $students, $teachers, $bbactivity, $roleids) =
+                $this->setup_course_students_teachers(
+                        ['enablecompletion' => true, 'groupmode' => strval(VISIBLEGROUPS), 'groupmodeforce' => 1],
+                        $numstudents, $numteachers, $groupsnum);
+
+        $context = context_course::instance($course->id);
+        $this->setUser($teachers[0]);
+        $users = bigbluebuttonbn_get_users_select($context, $bbactivity);
+        $this->assertCount($numstudents + $numteachers, $users);
+        $this->setUser($teachers[1]);
+        $users = bigbluebuttonbn_get_users_select($context, $bbactivity);
+        $this->assertCount($numstudents + $numteachers, $users);
+        $this->setUser($teachers[1]);
+        $users = bigbluebuttonbn_get_users_select($context, $bbactivity);
+        $this->assertCount($numstudents + $numteachers, $users);
+    }
+
+    /**
+     * Generate a course, several students and several groups
+     *
+     * @param object $courserecord
+     * @param int $numstudents
+     * @param int $numteachers
+     * @param int $groupsnum
+     * @return array
+     * @throws coding_exception
+     * @throws dml_exception
+     * @throws moodle_exception
+     */
+    protected function setup_course_students_teachers($courserecord, $numstudents, $numteachers, $groupsnum) {
+        global $DB;
+        $generator = $this->getDataGenerator();
+        $course = $generator->create_course($courserecord);
+        $groups = [];
+        for ($i = 0; $i < $groupsnum; $i++) {
+            $groups[] = $generator->create_group(array('courseid' => $course->id));
+        }
+        $group1 = $generator->create_group(array('courseid' => $course->id));
+        $group2 = $generator->create_group(array('courseid' => $course->id));
+
+        $roleids = $DB->get_records_menu('role', null, '', 'shortname, id');
+
+        $students = [];
+        for ($i = 0; $i < $numstudents; $i++) {
+            $student = $generator->create_user();
+            $generator->enrol_user($student->id, $course->id, $roleids['student']);
+            $groupid = $groups[$i % $groupsnum]->id;
+            groups_add_member($groupid, $student->id);
+            $students[] = $student;
+        }
+
+        $teachers = [];
+        for ($i = 0; $i < $numteachers; $i++) {
+            $teacher = $generator->create_user();
+            $generator->enrol_user($teacher->id, $course->id, $roleids['teacher']);
+            $groupid = $groups[$i % $groupsnum]->id;
+            groups_add_member($groupid, $teacher->id);
+            $teachers[] = $teacher;
+        }
+        $bbactivity = $generator->create_module(
+                'bigbluebuttonbn',
+                array('course' => $course->id),
+                ['visible' => true]);
+
+        get_fast_modinfo(0, 0, true);
+        return array($course, $groups, $students, $teachers, $bbactivity, $roleids);
+    }
 }
+

--- a/tests/recordings_test.php
+++ b/tests/recordings_test.php
@@ -70,7 +70,7 @@ class mod_bigbluebuttonbn_recordings_testcase extends advanced_testcase {
             $this->courses[] = $this->getDataGenerator()->create_course();
         }
         $bbngenerator = $this->getDataGenerator()->get_plugin_generator('mod_bigbluebuttonbn');
-        /* @var $bbngenerator mod_bigbluebuttonbn_generator*/
+        /* @var $bbngenerator mod_bigbluebuttonbn_generator */
         foreach (static::BB_ACTIVITIES as $aname => $activity) {
             $bbactivity = $bbngenerator->create_instance(
                 [


### PR DESCRIPTION
In the participant menu of the activity, make sure that we can only see the users that are in the same group if it is the constraint set.

If we chose separate groups and have no right to see other users, then we cannot see other group as a teacher or any user part of a group
* Add unit/behat test to test this specific feature
* Make sure that we just get the right group mode (check the forced course group flag) in the activity view page

![Sélection_510](https://user-images.githubusercontent.com/4372386/74174317-01c63a00-4c34-11ea-968d-6600ee065174.png)
