### PR TITLE
CONTRIB-7961 When importing records in a record only BBB activity, then is show all the recordings

### DIFF
--- a/tests/behat/recordings_import.feature
+++ b/tests/behat/recordings_import.feature
@@ -52,3 +52,10 @@ Feature: Manage and list recordings
     Then I follow "RecordingsOnly1"
     And I should see "Recording 1"
     And I should see "Recording 2"
+    Then I wait until the page is ready
+    Then I go to the courses management page
+    And I follow "Test Course 2"
+    Then I follow "View"
+    Then I follow "RecordingsOnly2"
+    And I should not see "Recording 1"
+    And I should not see "Recording 2"

--- a/viewlib.php
+++ b/viewlib.php
@@ -257,8 +257,9 @@ function bigbluebuttonbn_view_render_recordings(&$bbbsession, $enabledfeatures, 
     );
     if ($enabledfeatures['importrecordings']) {
         // Get recording links.
+        $bigbluebuttonbnid = $bbbsession['bigbluebuttonbn']->id;
         $recordingsimported = bigbluebuttonbn_get_recordings_imported_array(
-            $bbbsession['course']->id, $bigbluebuttonbnid, $enabledfeatures['showroom']
+            $bbbsession['course']->id, $bigbluebuttonbnid,  true
         );
         /* Perform aritmetic addition instead of merge so the imported recordings corresponding to existent
          * recordings are not included. */


### PR DESCRIPTION
This was due to the type of recording and the features enabled in this type. For BIGBLUEBUTTONBN_TYPE_RECORDING_ONLY, the feature ''showroom' in the was not enabled. Down the line, we check for this feature and if it is enabled, we filter it accordingly.
There was a specific branch for testing this feature through behat but this is not ready yet.