### PR TITLE
CONTRIB-7972, CONTRIB-7973

### DIFF
--- a/locallib.php
+++ b/locallib.php
@@ -650,15 +650,32 @@ function bigbluebuttonbn_get_users(context $context = null) {
  * Returns an array containing all the users in a context wrapped for html select element.
  *
  * @param context $context
- *
+ * @param null $bbactivity
  * @return array $users
+ * @throws coding_exception
+ * @throws moodle_exception
  */
-function bigbluebuttonbn_get_users_select(context $context = null) {
+function bigbluebuttonbn_get_users_select(context $context = null, $bbactivity = null) {
+    // CONTRIB-7972, check the group of current user and course group mode.
+    $groups = null;
     $users = (array) get_enrolled_users($context, '', 0, 'u.*', null, 0, 0, true);
-    foreach ($users as $key => $value) {
-        $users[$key] = array('id' => $value->id, 'name' => fullname($value));
+    if ($bbactivity) {
+        list($course, $cm) = get_course_and_cm_from_instance($bbactivity->id, 'bigbluebuttonbn');
+        $groupmode = groups_get_activity_groupmode($cm);
+        if ($groupmode == SEPARATEGROUPS && !has_capability('moodle/site:accessallgroups', $context)) {
+            global $USER;
+            $groups = groups_get_all_groups($course->id, $USER->id);
+            $users = [];
+            foreach ($groups as $g) {
+                $users += (array) get_enrolled_users($context, '', $g->id, 'u.*', null, 0, 0, true);
+            }
+        }
     }
-    return $users;
+    return array_map(
+            function($u) {
+                return array('id' => $u->id, 'name' => fullname($u));
+            },
+            $users);
 }
 
 /**
@@ -714,10 +731,10 @@ function bigbluebuttonbn_get_role($id) {
  * Returns an array to populate a list of participants used in mod_form.js.
  *
  * @param context $context
- *
+ * @param null|object $bbactivity
  * @return array $data
  */
-function bigbluebuttonbn_get_participant_data($context) {
+function bigbluebuttonbn_get_participant_data($context, $bbactivity = null) {
     $data = array(
         'all' => array(
             'name' => get_string('mod_form_field_participant_list_type_all', 'bigbluebuttonbn'),
@@ -730,8 +747,8 @@ function bigbluebuttonbn_get_participant_data($context) {
       );
     $data['user'] = array(
         'name' => get_string('mod_form_field_participant_list_type_user', 'bigbluebuttonbn'),
-        'children' => bigbluebuttonbn_get_users_select($context)
-      );
+        'children' => bigbluebuttonbn_get_users_select($context, $bbactivity),
+    );
     return $data;
 }
 
@@ -1904,21 +1921,11 @@ function bigbluebuttonbn_get_recording_table($bbbsession, $recordings, $tools = 
             $meetingid = $shortmeetingid[0];
         }
         // Check if the record belongs to a Visible Group type.
-        $sql = "SELECT bigbluebuttonbn.id, cm.id, cm.groupmode
-                 FROM {bigbluebuttonbn} bigbluebuttonbn
-                 JOIN {modules} m
-                   ON m.name = :bigbluebuttonbn
-                 JOIN {course_modules} cm
-                   ON cm.instance = bigbluebuttonbn.id
-                  AND cm.module = m.id
-                WHERE bigbluebuttonbn.meetingid = :meetingid";
-        $params = array('bigbluebuttonbn' => 'bigbluebuttonbn', 'meetingid' => $meetingid);
-
-        $groupmode = $DB->get_record_sql($sql, $params, IGNORE_MULTIPLE);
-
+        list($course, $cm) = get_course_and_cm_from_cmid($bbbsession['cm']->id);
+        $groupmode = groups_get_activity_groupmode($cm);
         $displayrow = true;
-        if ((isset($groupmode->groupmode) && (int)$groupmode->groupmode != VISIBLEGROUPS)
-            && !$bbbsession['administrator'] && !$bbbsession['moderator']) {
+        if (($groupmode != VISIBLEGROUPS)
+                && !$bbbsession['administrator'] && !$bbbsession['moderator']) {
             $groupid = explode('[', $recording['meetingID']);
             if (isset($groupid[1])) {
                 // It is a group recording and the user is not moderator/administrator. Recording should not be included by default.

--- a/mod_form.php
+++ b/mod_form.php
@@ -104,7 +104,7 @@ class mod_bigbluebuttonbn_mod_form extends moodleform_mod {
         $this->add_action_buttons();
         // JavaScript for locales.
         $PAGE->requires->strings_for_js(array_keys(bigbluebuttonbn_get_strings_for_js()), 'bigbluebuttonbn');
-        $jsvars['participantData'] = bigbluebuttonbn_get_participant_data($context);
+        $jsvars['participantData'] = bigbluebuttonbn_get_participant_data($context, $bigbluebuttonbn);
         $jsvars['participantList'] = $participantlist;
         $jsvars['iconsEnabled'] = (boolean)$cfg['recording_icons_enabled'];
         $jsvars['pixIconDelete'] = (string)$OUTPUT->pix_icon('t/delete', get_string('delete'), 'moodle');


### PR DESCRIPTION
In the participant menu of the activity, make sure that we can only see the users that are in the same group if it is the constraint set (#173)

If we choose separate groups and have no right to see other users, then we cannot see other group as a teacher or any user part of a group
* Add unit/behat test to test this specific feature
* Make sure that we just get the right group mode (check the forced course group flag) in the activity view page