### PR TITLE
CONTRIB-7895: End session does not work on the room list

### DIFF
--- a/classes/output/index.php
+++ b/classes/output/index.php
@@ -218,6 +218,7 @@ class index implements renderable {
             $actions .= '<form name="form1" method="post" action="">'."\n";
             $actions .= '  <INPUT type="hidden" name="id" value="'.$course->id.'">'."\n";
             $actions .= '  <INPUT type="hidden" name="a" value="'.$bigbluebuttonbn->id.'">'."\n";
+            $actions .= '  <INPUT type="hidden" name="action" value="end">'."\n";
             if ($groupobj != null) {
                 $actions .= '  <INPUT type="hidden" name="g" value="'.$groupobj->id.'">'."\n";
             }


### PR DESCRIPTION
When looking a the room list as a table the End Session button did not work (the session was still running). 

Note that we have to add the "activities block" in order to see all activities in a course and access the page.

 