### PR TITLE
CONTRIB-7703 Meeting name is not required in the recording list

### DIFF
--- a/locallib.php
+++ b/locallib.php
@@ -1385,11 +1385,9 @@ function bigbluebuttonbn_get_recording_data_row($bbbsession, $recording, $tools 
     }
     $rowdata = new stdClass();
     // Set recording_types.
-    $rowdata->recording = bigbluebuttonbn_get_recording_data_row_types($recording, $bbbsession);
-    // Set meeting name.
-    $rowdata->meeting = bigbluebuttonbn_get_recording_data_row_meeting($recording, $bbbsession);
+    $rowdata->playback = bigbluebuttonbn_get_recording_data_row_types($recording, $bbbsession);
     // Set activity name.
-    $rowdata->activity = bigbluebuttonbn_get_recording_data_row_meta_activity($recording, $bbbsession);
+    $rowdata->recording = bigbluebuttonbn_get_recording_data_row_meta_activity($recording, $bbbsession);
     // Set activity description.
     $rowdata->description = bigbluebuttonbn_get_recording_data_row_meta_description($recording, $bbbsession);
     if (bigbluebuttonbn_get_recording_data_preview_enabled($bbbsession)) {
@@ -1894,12 +1892,10 @@ function bigbluebuttonbn_actionbar_render_button($recording, $data) {
 function bigbluebuttonbn_get_recording_columns($bbbsession) {
     $columns = array();
     // Initialize table headers.
-    $columns[] = array('key' => 'recording', 'label' => get_string('view_recording_recording', 'bigbluebuttonbn'),
+    $columns[] = array('key' => 'playback', 'label' => get_string('view_recording_playback', 'bigbluebuttonbn'),
+        'width' => '125px', 'allowHTML' => true); // Note: here a strange bug noted whilst changing the columns, ref CONTRIB
+    $columns[] = array('key' => 'recording', 'label' => get_string('view_recording_name', 'bigbluebuttonbn'),
         'width' => '125px', 'allowHTML' => true);
-    $columns[] = array('key' => 'meeting', 'label' => get_string('view_recording_meeting', 'bigbluebuttonbn'),
-        'sortable' => true, 'width' => '175px', 'allowHTML' => true);
-    $columns[] = array('key' => 'activity', 'label' => get_string('view_recording_activity', 'bigbluebuttonbn'),
-        'sortable' => true, 'width' => '175px', 'allowHTML' => true);
     $columns[] = array('key' => 'description', 'label' => get_string('view_recording_description', 'bigbluebuttonbn'),
         'sortable' => true, 'width' => '250px', 'allowHTML' => true);
     if (bigbluebuttonbn_get_recording_data_preview_enabled($bbbsession)) {
@@ -1957,8 +1953,7 @@ function bigbluebuttonbn_get_recording_table($bbbsession, $recordings, $tools = 
     $table->data = array();
     // Initialize table headers.
     $table->head[] = get_string('view_recording_playback', 'bigbluebuttonbn');
-    $table->head[] = get_string('view_recording_meeting', 'bigbluebuttonbn');
-    $table->head[] = get_string('view_recording_recording', 'bigbluebuttonbn');
+    $table->head[] = get_string('view_recording_name', 'bigbluebuttonbn');
     $table->head[] = get_string('view_recording_description', 'bigbluebuttonbn');
     if (bigbluebuttonbn_get_recording_data_preview_enabled($bbbsession)) {
         $table->head[] = get_string('view_recording_preview', 'bigbluebuttonbn');
@@ -2037,10 +2032,8 @@ function bigbluebuttonbn_get_recording_table_row($bbbsession, $recording, $rowda
     }
     $rowdata->date_formatted = str_replace(' ', '&nbsp;', $rowdata->date_formatted);
     $row->cells = array();
+    $row->cells[] = $texthead . $rowdata->playback . $texttail;
     $row->cells[] = $texthead . $rowdata->recording . $texttail;
-    $row->cells[] = $texthead . $rowdata->meeting . $texttail;
-
-    $row->cells[] = $texthead . $rowdata->activity . $texttail;
     $row->cells[] = $texthead . $rowdata->description . $texttail;
     if (bigbluebuttonbn_get_recording_data_preview_enabled($bbbsession)) {
         $row->cells[] = $rowdata->preview;

--- a/tests/behat/recordings_import.feature
+++ b/tests/behat/recordings_import.feature
@@ -52,3 +52,38 @@ Feature: Manage and list recordings
     Then I follow "RecordingsOnly1"
     And I should see "Recording 1"
     And I should see "Recording 2"
+
+
+  @javascript
+  Scenario: I check that I can import recordings into the Recording Only activity and that the list of
+    recording is displays the right information (Recording Name as name and Description)
+    When I log in as "admin"
+    Then I go to the courses management page
+    And I follow "Test Course 2"
+    Then I follow "View"
+    Then I follow "RecordingsOnly1"
+    Then I click on "Import recording links" "button"
+    Then I select "Test Course 1" from the "import_recording_links_select" singleselect
+    Then I wait until the page is ready
+    # We check column names regarding changes made in CONTRIB-7703.
+    And I should not see "Recording" in the "table.generaltable > thead > tr" "css_element"
+    And I should not see "Meeting" in the "table.generaltable > thead > tr" "css_element"
+    And I should see "Name" in the "table.generaltable > thead > tr" "css_element"
+    Then I select "Test Course 1" from the "import_recording_links_select" singleselect
+    # We check that columns are in the right order, see CONTRIB-7703.
+    Then I should see "Recording 1" in the "table.generaltable tr td.cell.c1" "css_element"
+    # add the first recording
+    And I click on "td.lastcol a" "css_element"
+    Then I wait until the page is ready
+    Then I click on "Yes" "button"
+    Then I wait until the page is ready
+    And I click on "Go back" "button"
+    Then I wait until the page is ready
+    And I should not see "Recording" in the "table > thead > tr" "css_element"
+    And I should not see "Meeting" in the "table > thead > tr" "css_element"
+    And I should see "Name" in the "table > thead > tr" "css_element"
+    # This should be refactored with the right classes for the table element
+    # We use javascript here to create the table so we don't get the same structure.
+    Then I should see "Recording 1" in the "#bigbluebuttonbn_recordings_table table.yui3-datatable-table tbody.yui3-datatable-data tr td:nth-child(2)" "css_element"
+    # Here we would need to test if there is no regression in the html by default view. This will have to be refactored
+    # alongside with the view

--- a/viewlib.php
+++ b/viewlib.php
@@ -116,7 +116,6 @@ function bigbluebuttonbn_view_render(&$bbbsession, $activity) {
     $output .= bigbluebuttonbn_view_warning_general($bbbsession);
 
     // Renders the rest of the page.
-    $output .= $OUTPUT->heading($bbbsession['meetingname'], 3);
     // Renders the completed description.
     $desc = file_rewrite_pluginfile_urls($bbbsession['meetingdescription'], 'pluginfile.php',
         $bbbsession['context']->id, 'mod_bigbluebuttonbn', 'intro', null);


### PR DESCRIPTION
On the BigblueButtonBN activity page, we would need to remove the Meeting column from the recording table/list.
This changes the following on the table:
* Remove the Meeting column from the recording table
* Rename the column "Recording" into "Name"