### PR TITLE
CONTRIB-7966 : Make sure that the Moderator by default setting take into account all roles

### DIFF
--- a/locallib.php
+++ b/locallib.php
@@ -2968,7 +2968,7 @@ function bigbluebuttonbn_settings_participants(&$renderer) {
             $renderer->render_group_element_configmultiselect(
                 'participant_moderator_default',
                 array_keys($owner),
-                array_merge($owner, $roles)
+                $owner + $roles // CONTRIB-7966: don't use array_merge here so it does not reindex the array.
             )
         );
     }


### PR DESCRIPTION
If a role has been deleted in the list of Moodle roles, then all the subsequent roles will not appear in the bigbluebuttonbn list of participant / roles.