### PR TITLE
Remove CAP_PREVENT

### DIFF
--- a/db/access.php
+++ b/db/access.php
@@ -84,9 +84,6 @@ $capabilities = array(
         'archetypes' => array(
             'manager' => CAP_ALLOW,
             'editingteacher' => CAP_ALLOW,
-            'teacher' => CAP_PREVENT,
-            'student' => CAP_PREVENT,
-            'guest' => CAP_PREVENT,
         ),
     ),
 
@@ -97,9 +94,6 @@ $capabilities = array(
         'archetypes' => array(
             'manager' => CAP_ALLOW,
             'editingteacher' => CAP_ALLOW,
-            'teacher' => CAP_PREVENT,
-            'student' => CAP_PREVENT,
-            'guest' => CAP_PREVENT,
         ),
     ),
 );


### PR DESCRIPTION
Causes totara unit test to fail. 

`vendor/bin/phpunit --colors totara_core_access_testcase totara/core/tests/access_test.php`