### PR TITLE
CONTRIB-8045 Bug fix for large lists

### DIFF
--- a/locallib.php
+++ b/locallib.php
@@ -1851,7 +1851,7 @@ function bigbluebuttonbn_actionbar_render_button($recording, $data) {
         $target .= '-' . $data['target'];
     }
     $id = 'recording-' . $target . '-' . $recording['recordID'];
-    $onclick = 'M.mod_bigbluebuttonbn.recordings.recording' . ucfirst($data['action']) . '(this);';
+    $onclick = 'M.mod_bigbluebuttonbn.recordings.recording' . ucfirst($data['action']) . '(this); return false;';
     if ((boolean) \mod_bigbluebuttonbn\locallib\config::get('recording_icons_enabled')) {
         // With icon for $manageaction.
         $iconattributes = array('id' => $id, 'class' => 'iconsmall');


### PR DESCRIPTION
Bug fix for large lists. The link is written as "#". The page goes to the top when the link is clicked. But the confirm box remains at the bottom of the page and is not clicked.