### PR TITLE
Add index (courseid) to bigbluebuttonbn_logs

### DIFF
--- a/db/install.xml
+++ b/db/install.xml
@@ -59,7 +59,7 @@
       <KEYS>
         <KEY NAME="primary" TYPE="primary" FIELDS="id"/>
       </KEYS>
-        <INDEXES>
+      <INDEXES>
         <INDEX NAME="courseid" UNIQUE="false" FIELDS="courseid"/>
       </INDEXES>
 

--- a/db/install.xml
+++ b/db/install.xml
@@ -59,6 +59,10 @@
       <KEYS>
         <KEY NAME="primary" TYPE="primary" FIELDS="id"/>
       </KEYS>
+        <INDEXES>
+        <INDEX NAME="courseid" UNIQUE="false" FIELDS="courseid"/>
+      </INDEXES>
+
     </TABLE>
   </TABLES>
 </XMLDB>


### PR DESCRIPTION
After running a very busy moodle site with a lot of BBB activities(more than 2000 simultaneous users in conferences) I realized that when users try to join conferences the following  SQL query is performed:
SELECT COUNT(*) from bigbluebuttonbn_logs WHERE courseid ...
This query consumes a lot of CPU time on the SQL server (MariaDB)  making the database to respond very slow. Adding the proposed index (courseid) made a huge difference.