### PR TITLE
CONTRIB-8158: Don't show the closingtime on the Dashboard if it isn't set in the activity instance

### DIFF
--- a/lib.php
+++ b/lib.php
@@ -500,8 +500,10 @@ function bigbluebuttonbn_print_overview_element($bigbluebuttonbn, $now) {
     $str .= '  </div>'."\n";
     $str .= '  <div class="info">'.get_string($start, 'bigbluebuttonbn').': '.userdate($bigbluebuttonbn->openingtime).
         '</div>'."\n";
-    $str .= '  <div class="info">'.get_string('ends_at', 'bigbluebuttonbn').': '.userdate($bigbluebuttonbn->closingtime)
-      .'</div>'."\n";
+    if (!empty($bigbluebuttonbn->closingtime)) {
+        $str .= '  <div class="info">'.get_string('ends_at', 'bigbluebuttonbn').': '.userdate($bigbluebuttonbn->closingtime)
+                .'</div>'."\n";
+    }
     $str .= '</div>'."\n";
     return $str;
 }


### PR DESCRIPTION
Before this patch, the bigbluebuttonbn_print_overview_element() function, which is called from bigbluebuttonbn_print_overview() which is deprecated since Moodle 3.8 but which is still called on previous Moodle core versions and from old-style Moodle Dashboard blocks, didn't check if $bigbluebuttonbn->closingtime is defined in the particular BBB activity instance or not.

As a result, users saw this line for BBB activity instances with a openingtime set but without a closingtime set.
Ends: Thursday, 1 January 1970, 1:00 AM

This patch fixes this flaw in a way that it only shows the closingtime in addition to the openingtime if the closingtime is really set in the BBB activity instance.