### PR TITLE
Fix #225 - Do not apply filters when creating calendar events

### DIFF
--- a/lib.php
+++ b/lib.php
@@ -805,7 +805,8 @@ function bigbluebuttonbn_process_post_save_event(&$bigbluebuttonbn) {
     $event->eventtype = BIGBLUEBUTTON_EVENT_MEETING_START;
     $event->type = CALENDAR_EVENT_TYPE_ACTION;
     $event->name = get_string('calendarstarts', 'bigbluebuttonbn', $bigbluebuttonbn->name);
-    $event->description = format_module_intro('bigbluebuttonbn', $bigbluebuttonbn, $bigbluebuttonbn->coursemodule);
+    $event->description = format_module_intro('bigbluebuttonbn', $bigbluebuttonbn, $bigbluebuttonbn->coursemodule, false);
+    $event->format      = FORMAT_HTML;
     $event->courseid = $bigbluebuttonbn->course;
     $event->groupid = 0;
     $event->userid = 0;


### PR DESCRIPTION
See MDL-68645 for details.

Note: this has only been tested on 3.9 - I haven't checked to see if this causes problems with older branches, but it fixes the issue in 3.9.

thanks!