### PR TITLE
Add default welcome message to settings

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,5 @@
 
 /vendor/*
 !/vendor/firebase/
+
+.DS_Store

--- a/classes/locallib/config.php
+++ b/classes/locallib/config.php
@@ -103,6 +103,7 @@ class config {
             'clienttype_editable' => true,
             'muteonstart_default' => false,
             'muteonstart_editable' => false,
+            'welcome_default' => '',
         );
     }
 
@@ -209,6 +210,7 @@ class config {
                'clienttype_default' => self::get('clienttype_default'),
                'muteonstart_editable' => self::get('muteonstart_editable'),
                'muteonstart_default' => self::get('muteonstart_default'),
+               'welcome_default' => self::get('welcome_default'),
           );
     }
 }

--- a/classes/settings/renderer.php
+++ b/classes/settings/renderer.php
@@ -105,6 +105,23 @@ class renderer {
     }
 
     /**
+     * Render a html editor element in a group.
+     *
+     * @param string    $name
+     * @param object    $default
+     * @param string    $type
+     *
+     * @return Object
+     */
+    public function render_group_element_textarea($name, $default = null, $type = PARAM_RAW) {
+        $item = new \admin_setting_configtextarea('bigbluebuttonbn_' . $name,
+                get_string('config_' . $name, 'bigbluebuttonbn'),
+                get_string('config_' . $name . '_description', 'bigbluebuttonbn'),
+                $default, $type);
+        return $item;
+    }
+
+    /**
      * Render a checkbox element in a group.
      *
      * @param string    $name

--- a/lang/en/bigbluebuttonbn.php
+++ b/lang/en/bigbluebuttonbn.php
@@ -225,6 +225,10 @@ $string['config_muteonstart_default'] = 'Mute on start enabled by default';
 $string['config_muteonstart_default_description'] = 'If enabled the session will be muted on start.';
 $string['config_muteonstart_editable'] = 'Mute on start can be edited';
 $string['config_muteonstart_editable_description'] = 'Mute on start by default can be edited when the instance is added or updated.';
+$string['config_welcome_default'] = 'Default welcome message';
+$string['config_welcome_default_description'] = 'Replaces the default message setted up for the BigBlueButton server. The message can includes keywords  (%%CONFNAME%%, %%DIALNUM%%, %%CONFNUM%%) which will be substituted automatically, and also html tags like <b>...</b> or <i></i> ';
+$string['config_default_messages'] = 'Default messages';
+$string['config_default_messages_description'] = 'Set message defaults for activities';
 
 $string['general_error_unable_connect'] = 'Unable to connect. Please check the url of the BigBlueButton server AND check to see if the BigBlueButton server is running.';
 $string['general_error_not_allowed_to_create_instances'] = 'User is not allowed to create any type of instances.';

--- a/locallib.php
+++ b/locallib.php
@@ -3027,6 +3027,21 @@ function bigbluebuttonbn_settings_muteonstart(&$renderer) {
 }
 
 /**
+ * Helper function renders default messages settings.
+ *
+ * @param object $renderer
+ *
+ * @return void
+ */
+function bigbluebuttonbn_settings_default_messages(&$renderer) {
+    $renderer->render_group_header('default_messages');
+    $renderer->render_group_element(
+        'welcome_default',
+        $renderer->render_group_element_textarea('welcome_default', '', PARAM_TEXT)
+    );
+}
+
+/**
  * Helper function renders extended settings if any of the features there is enabled.
  *
  * @param object $renderer

--- a/mod_form.php
+++ b/mod_form.php
@@ -292,7 +292,7 @@ class mod_bigbluebuttonbn_mod_form extends moodleform_mod {
         $field = ['type' => 'textarea', 'name' => 'welcome', 'data_type' => PARAM_TEXT,
             'description_key' => 'mod_form_field_welcome'];
         $this->bigbluebuttonbn_mform_add_element($mform, $field['type'], $field['name'], $field['data_type'],
-            $field['description_key'], '', ['wrap' => 'virtual', 'rows' => 5, 'cols' => '60']);
+            $field['description_key'], $cfg['welcome_default'], ['wrap' => 'virtual', 'rows' => 5, 'cols' => '60']);
         $field = ['type' => 'hidden', 'name' => 'voicebridge', 'data_type' => PARAM_INT,
             'description_key' => null];
         if ($cfg['voicebridge_editable']) {

--- a/settings.php
+++ b/settings.php
@@ -55,6 +55,7 @@ if ($hassiteconfig) {
     bigbluebuttonbn_settings_notifications($renderer);
     bigbluebuttonbn_settings_clienttype($renderer);
     bigbluebuttonbn_settings_muteonstart($renderer);
+    bigbluebuttonbn_settings_default_messages($renderer);
     // Renders settings for extended capabilities.
     bigbluebuttonbn_settings_extended($renderer);
 }

--- a/version.php
+++ b/version.php
@@ -26,7 +26,7 @@
 
 defined('MOODLE_INTERNAL') || die;
 
-$plugin->version = 2019101001;
+$plugin->version = 2019101003;
 $plugin->requires = 2016120500;
 $plugin->cron = 0;
 $plugin->component = 'mod_bigbluebuttonbn';


### PR DESCRIPTION
Adds a textarea to the settings page, where you can set a default welcome message.
The text will be set in the "Welcome message" field in the activity and can be overwritten by the teacher.