### PR TITLE
CONTRIB-8038 mod_bigbluebutton: Recordings should be visible to admins

### DIFF
--- a/locallib.php
+++ b/locallib.php
@@ -2033,6 +2033,10 @@ function bigbluebuttonbn_include_recording_table_row($bbbsession, $recording) {
     if (isset($recording['imported'])) {
         return true;
     }
+    // Administrators and moderators are always allowed.
+    if ($bbbsession['administrator'] || $bbbsession['moderator']) {
+        return true;
+    }
     // When groups are enabled, exclude those to which the user doesn't have access to.
     if (isset($bbbsession['group']) && $recording['meetingID'] != $bbbsession['meetingid']) {
         return false;


### PR DESCRIPTION
If activity in group mode, then the admin or moderators should be able to see all recordings regardless of the activity group mode.

The issue at hand was that bigbluebuttonbn_include_recording_table_row was hiding the row if the BBB session has a group mode set.
This patch will resolve the issue for admins, but the issue will still likely to be there for other users. The check made in this function are somewhat redundant with the ones made in bigbluebuttonbn_get_recording_table, so we might have to go further here and refactor at least the bigbluebuttonbn_get_recording_data_row so it does not add further checkings (call to bigbluebuttonbn_include_recording_table_row).

