### PR TITLE
Make setUp() and tearDown() signatures compatible with PHPUnit 8.5 in Moodle 3.10

### DIFF
--- a/tests/lib_test.php
+++ b/tests/lib_test.php
@@ -94,7 +94,7 @@ class mod_bigbluebuttonbn_lib_testcase extends advanced_testcase {
         return $data;
     }
 
-    public function setUp() {
+    public function setUp(): void {
         global $CFG;
         parent::setUp();
         set_config('enablecompletion', true); // Enable completion for all tests.

--- a/tests/locallib_test.php
+++ b/tests/locallib_test.php
@@ -42,7 +42,7 @@ class mod_bigbluebuttonbn_locallib_testcase extends advanced_testcase {
      *
      * @throws coding_exception
      */
-    public function tearDown() {
+    public function tearDown(): void {
         parent::tearDown();
         $this->getDataGenerator()->get_plugin_generator('mod_bigbluebuttonbn')
             ->bigbluebuttonbn_clean_recordings_array_fetch();

--- a/tests/privacy_provider_test.php
+++ b/tests/privacy_provider_test.php
@@ -59,7 +59,7 @@ class mod_bigbluebuttonbn_privacy_provider_testcase extends \core_privacy\tests\
      *
      * @throws coding_exception
      */
-    public function tearDown() {
+    public function tearDown(): void {
         parent::tearDown();
         $this->getDataGenerator()->get_plugin_generator('mod_bigbluebuttonbn')->bigbluebuttonbn_clean_recordings_array_fetch();
     }

--- a/tests/recordings_test.php
+++ b/tests/recordings_test.php
@@ -56,7 +56,7 @@ class mod_bigbluebuttonbn_recordings_testcase extends advanced_testcase {
         'BBACTIVITY3' => ['courseindex' => 1, 'type' => BIGBLUEBUTTONBN_TYPE_RECORDING_ONLY, 'nbrecordings' => 3],
     ];
 
-    public function setUp() {
+    public function setUp(): void {
         parent::setUp();
 
         $maxcourseindexindex = array_reduce(
@@ -93,7 +93,7 @@ class mod_bigbluebuttonbn_recordings_testcase extends advanced_testcase {
      *
      * @throws coding_exception
      */
-    public function tearDown() {
+    public function tearDown(): void {
         parent::tearDown();
         $this->getDataGenerator()->get_plugin_generator('mod_bigbluebuttonbn')
             ->bigbluebuttonbn_clean_recordings_array_fetch();


### PR DESCRIPTION
This is backwards compatible with PHPUnit 7.x used in Moodle 3.9.