### PR TITLE
bbb_ajax.php: declare READ_ONLY_SESSION

### DIFF
--- a/bbb_ajax.php
+++ b/bbb_ajax.php
@@ -23,6 +23,8 @@
  * @author    Jesus Federico  (jesus [at] blindsidenetworks [dt] com)
  */
 
+define('READ_ONLY_SESSION', true);
+
 require(__DIR__.'/../../config.php');
 require_once(__DIR__.'/locallib.php');
 require_once(__DIR__.'/brokerlib.php');


### PR DESCRIPTION
Declare that calls to bbb_ajax.php only require a read-only session,
which reduces session lock contention on pages calling making AJAX
requests to this endpoint.

See-also: [MDL-58018](https://tracker.moodle.org/browse/MDL-58018)