### PR TITLE
CONTRIB-8393: Fix use of invalid Level 2 Namespaces 

### DIFF
--- a/bbb_view.php
+++ b/bbb_view.php
@@ -79,7 +79,7 @@ if ($timeline || $index) {
         exit;
     }
 
-    $bbbsession = mod_bigbluebuttonbn\locallib\bigbluebutton::build_bbb_session($cm, $course, $bigbluebuttonbn);
+    $bbbsession = mod_bigbluebuttonbn\local\bigbluebutton::build_bbb_session($cm, $course, $bigbluebuttonbn);
 
     // Check status and set extra values.
     $activitystatus = bigbluebuttonbn_view_get_activity_status($bbbsession);
@@ -372,7 +372,7 @@ function bigbluebuttonbn_bbb_view_create_meeting_data(&$bbbsession) {
  * @return string
  */
 function bigbluebuttonbn_bbb_view_create_meeting_data_record($record) {
-    if ((boolean)\mod_bigbluebuttonbn\locallib\config::recordings_enabled() && $record) {
+    if ((boolean)\mod_bigbluebuttonbn\local\config::recordings_enabled() && $record) {
         return 'true';
     }
     return 'false';
@@ -385,7 +385,7 @@ function bigbluebuttonbn_bbb_view_create_meeting_data_record($record) {
  * @return integer
  */
 function bigbluebuttonbn_bbb_view_create_meeting_data_duration($closingtime) {
-    if ((boolean)\mod_bigbluebuttonbn\locallib\config::get('scheduled_duration_enabled')) {
+    if ((boolean)\mod_bigbluebuttonbn\local\config::get('scheduled_duration_enabled')) {
         return bigbluebuttonbn_get_duration($closingtime);
     }
     return 0;

--- a/brokerlib.php
+++ b/brokerlib.php
@@ -558,7 +558,7 @@ function bigbluebuttonbn_broker_recording_ready($params, $bigbluebuttonbn) {
     try {
         $decodedparameters = \Firebase\JWT\JWT::decode(
             $params['signed_parameters'],
-            \mod_bigbluebuttonbn\locallib\config::get('shared_secret'),
+            \mod_bigbluebuttonbn\local\config::get('shared_secret'),
             array('HS256')
         );
     } catch (Exception $e) {
@@ -665,7 +665,7 @@ function bigbluebuttonbn_broker_meeting_events($bigbluebuttonbn) {
         // Verify the authenticity of the request.
         $token = \Firebase\JWT\JWT::decode(
             $authorization[1],
-            \mod_bigbluebuttonbn\locallib\config::get('shared_secret'),
+            \mod_bigbluebuttonbn\local\config::get('shared_secret'),
             array('HS512')
         );
 
@@ -861,7 +861,7 @@ function bigbluebuttonbn_broker_get_recording_data($bbbsession, $params, $enable
     $tabledata = array();
     $typeprofiles = bigbluebuttonbn_get_instance_type_profiles();
     $tabledata['activity'] = bigbluebuttonbn_view_get_activity_status($bbbsession);
-    $tabledata['ping_interval'] = (int) \mod_bigbluebuttonbn\locallib\config::get('waitformoderator_ping_interval') * 1000;
+    $tabledata['ping_interval'] = (int) \mod_bigbluebuttonbn\local\config::get('waitformoderator_ping_interval') * 1000;
     $tabledata['locale'] = bigbluebuttonbn_get_localcode();
     $tabledata['profile_features'] = $typeprofiles[0]['features'];
     $tabledata['recordings_html'] = $bbbsession['bigbluebuttonbn']->recordings_html == '1';

--- a/classes/external.php
+++ b/classes/external.php
@@ -231,7 +231,7 @@ class mod_bigbluebuttonbn_external extends external_api {
             array(
                 'cmid' => $cmid
             ));
-        $canjoin = \mod_bigbluebuttonbn\locallib\bigbluebutton::can_join_meeting($cmid);
+        $canjoin = \mod_bigbluebuttonbn\local\bigbluebutton::can_join_meeting($cmid);
         $canjoin['cmid'] = $cmid;
         return $canjoin;
     }

--- a/classes/local/bigbluebutton.php
+++ b/classes/local/bigbluebutton.php
@@ -23,7 +23,7 @@
  * @author    Jesus Federico  (jesus [at] blindsidenetworks [dt] com)
  */
 
-namespace mod_bigbluebuttonbn\locallib;
+namespace mod_bigbluebuttonbn\local;
 
 use context_module;
 

--- a/classes/local/config.php
+++ b/classes/local/config.php
@@ -23,12 +23,12 @@
  * @author    Jesus Federico  (jesus [at] blindsidenetworks [dt] com)
  */
 
-namespace mod_bigbluebuttonbn\locallib;
+namespace mod_bigbluebuttonbn\local;
 
 use mod_bigbluebuttonbn\local\bbb_constants;
 
 defined('MOODLE_INTERNAL') || die();
-
+global $CFG;
 require_once($CFG->dirroot . '/mod/bigbluebuttonbn/locallib.php');
 
 /**

--- a/classes/local/helpers/instance.php
+++ b/classes/local/helpers/instance.php
@@ -181,7 +181,7 @@ class instance {
         if (isset($bigbluebuttonbn->add) && !empty($bigbluebuttonbn->add)) {
             $action = get_string('mod_form_field_notification_msg_created', 'bigbluebuttonbn');
         }
-        \mod_bigbluebuttonbn\locallib\notifier::notify_instance_updated($bigbluebuttonbn, $action);
+        \mod_bigbluebuttonbn\local\notifier::notify_instance_updated($bigbluebuttonbn, $action);
     }
 
     /**

--- a/classes/local/helpers/reset.php
+++ b/classes/local/helpers/reset.php
@@ -120,7 +120,7 @@ class reset {
     public static function bigbluebuttonbn_reset_course_items() {
         $items = array("events" => 0, "tags" => 0, "logs" => 0);
         // Include recordings only if enabled.
-        if ((boolean) \mod_bigbluebuttonbn\locallib\config::recordings_enabled()) {
+        if ((boolean) \mod_bigbluebuttonbn\local\config::recordings_enabled()) {
             $items["recordings"] = 0;
         }
         return $items;

--- a/classes/local/mobileview.php
+++ b/classes/local/mobileview.php
@@ -22,7 +22,7 @@
  * @license   http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 
-namespace mod_bigbluebuttonbn\locallib;
+namespace mod_bigbluebuttonbn\local;
 
 defined('MOODLE_INTERNAL') || die();
 global $CFG;
@@ -139,7 +139,7 @@ class mobileview {
      * @return string
      */
     public static function create_meeting_data_record($record) {
-        if ((boolean)\mod_bigbluebuttonbn\locallib\config::recordings_enabled() && $record) {
+        if ((boolean)\mod_bigbluebuttonbn\local\config::recordings_enabled() && $record) {
             return 'true';
         }
         return 'false';
@@ -152,7 +152,7 @@ class mobileview {
      * @return integer
      */
     public static function create_meeting_data_duration($closingtime) {
-        if ((boolean)\mod_bigbluebuttonbn\locallib\config::get('scheduled_duration_enabled')) {
+        if ((boolean)\mod_bigbluebuttonbn\local\config::get('scheduled_duration_enabled')) {
             return bigbluebuttonbn_get_duration($closingtime);
         }
         return 0;

--- a/classes/local/notifier.php
+++ b/classes/local/notifier.php
@@ -23,13 +23,13 @@
  * @author    Jesus Federico  (jesus [at] blindsidenetworks [dt] com)
  */
 
-namespace mod_bigbluebuttonbn\locallib;
+namespace mod_bigbluebuttonbn\local;
 
 use html_writer;
 use mod_bigbluebuttonbn\plugin;
 
 defined('MOODLE_INTERNAL') || die();
-
+global $CFG;
 require_once($CFG->dirroot . '/mod/bigbluebuttonbn/locallib.php');
 
 /**
@@ -117,7 +117,7 @@ class notifier
      *
      * @param object $bigbluebuttonbn
      *
-     * @return void
+     * @return string
      */
     public static function htmlmsg_recording_ready($bigbluebuttonbn) {
         return '<p>'.get_string('email_body_recording_ready_for', 'bigbluebuttonbn').

--- a/classes/output/import_view.php
+++ b/classes/output/import_view.php
@@ -86,7 +86,7 @@ class import_view implements renderable, templatable {
             }
             $recordings = bigbluebuttonbn_get_allrecordings(
                 $selected, $bigbluebuttonbnid, false,
-                (boolean)\mod_bigbluebuttonbn\locallib\config::get('importrecordings_from_deleted_enabled')
+                (boolean)\mod_bigbluebuttonbn\local\config::get('importrecordings_from_deleted_enabled')
             );
             // Exclude the ones that are already imported.
             if (!empty($recordings)) {

--- a/classes/output/mobile.php
+++ b/classes/output/mobile.php
@@ -28,7 +28,7 @@ namespace mod_bigbluebuttonbn\output;
 defined('MOODLE_INTERNAL') || die();
 
 use mod_bigbluebuttonbn\local\bbb_constants;
-use mod_bigbluebuttonbn\locallib\bigbluebutton;
+use mod_bigbluebuttonbn\local\bigbluebutton;
 
 require_once($CFG->dirroot . '/mod/bigbluebuttonbn/locallib.php');
 require_once($CFG->dirroot . '/lib/grouplib.php');
@@ -73,7 +73,7 @@ class mobile {
         $context = $bbbsession['context'];
 
         // Check activity status.
-        $activitystatus = \mod_bigbluebuttonbn\locallib\mobileview::get_activity_status($bbbsession);
+        $activitystatus = \mod_bigbluebuttonbn\local\mobileview::get_activity_status($bbbsession);
         if ($activitystatus == 'not_started') {
             $message = get_string('view_message_conference_not_started', 'bigbluebuttonbn');
 
@@ -133,7 +133,7 @@ class mobile {
         // Logic of bbb_view for join to session.
         // If user is not administrator nor moderator (user is student) and waiting is required.
         if (!$bbbsession['administrator'] && !$bbbsession['moderator'] && $bbbsession['wait']) {
-            $canjoin = \mod_bigbluebuttonbn\locallib\bigbluebutton::can_join_meeting($args->cmid);
+            $canjoin = \mod_bigbluebuttonbn\local\bigbluebutton::can_join_meeting($args->cmid);
             if (!$canjoin['can_join']) {
                 $message = get_string('view_message_conference_wait_for_moderator', 'bigbluebuttonbn');
                 return (self::mobile_print_notification($bigbluebuttonbn, $cm, $message));
@@ -145,8 +145,8 @@ class mobile {
 
             // The meeting doesnt exist in BBB server, must be created.
             $response = bigbluebuttonbn_get_create_meeting_array(
-                \mod_bigbluebuttonbn\locallib\mobileview::create_meeting_data($bbbsession),
-                \mod_bigbluebuttonbn\locallib\mobileview::create_meeting_metadata($bbbsession),
+                \mod_bigbluebuttonbn\local\mobileview::create_meeting_data($bbbsession),
+                \mod_bigbluebuttonbn\local\mobileview::create_meeting_metadata($bbbsession),
                 $bbbsession['presentation']['name'],
                 $bbbsession['presentation']['url']
             );
@@ -193,7 +193,7 @@ class mobile {
 
         // Build final url to BBB.
         $bbbsession['createtime'] = $meetinginfo['createTime'];
-        $urltojoin = \mod_bigbluebuttonbn\locallib\mobileview::build_url_join_session($bbbsession);
+        $urltojoin = \mod_bigbluebuttonbn\local\mobileview::build_url_join_session($bbbsession);
 
         // Check groups access and show message.
         $msjgroup = array();

--- a/classes/task/send_notification.php
+++ b/classes/task/send_notification.php
@@ -25,7 +25,7 @@
 namespace mod_bigbluebuttonbn\task;
 
 use core\task\adhoc_task;
-use \mod_bigbluebuttonbn\locallib\notifier;
+use \mod_bigbluebuttonbn\local\notifier;
 
 defined('MOODLE_INTERNAL') || die();
 
@@ -58,6 +58,6 @@ class send_notification extends adhoc_task
         $data = $this->get_custom_data();
         mtrace("Execute send_notification task: Sending notification to user {$data->receiver->id}");
         // Process the completion.
-        \mod_bigbluebuttonbn\locallib\notifier::send_notification($data->sender, $data->receiver, $data->htmlmsg);
+        \mod_bigbluebuttonbn\local\notifier::send_notification($data->sender, $data->receiver, $data->htmlmsg);
     }
 }

--- a/import_view.php
+++ b/import_view.php
@@ -47,7 +47,7 @@ if (!isset($SESSION) || !isset($SESSION->bigbluebuttonbn_bbbsession)) {
     print_error('view_error_invalid_session', plugin::COMPONENT);
 }
 
-if (!(boolean)\mod_bigbluebuttonbn\locallib\config::importrecordings_enabled()) {
+if (!(boolean)\mod_bigbluebuttonbn\local\config::importrecordings_enabled()) {
     print_error('view_message_importrecordings_disabled', plugin::COMPONENT);
 }
 

--- a/lib.php
+++ b/lib.php
@@ -587,7 +587,7 @@ function mod_bigbluebuttonbn_core_calendar_provide_event_action(
 function bigbluebuttonbn_extend_settings_navigation(settings_navigation $settingsnav, navigation_node $nodenav) {
     global $PAGE, $USER;
     // Don't add validate completion if the callback for meetingevents is NOT enabled.
-    if (!(boolean)\mod_bigbluebuttonbn\locallib\config::get('meetingevents_enabled')) {
+    if (!(boolean)\mod_bigbluebuttonbn\local\config::get('meetingevents_enabled')) {
         return;
     }
     // Don't add validate completion if user is not allowed to edit the activity.

--- a/locallib.php
+++ b/locallib.php
@@ -129,7 +129,7 @@ function bigbluebuttonbn_get_join_url(
     if (!is_null($createtime)) {
         $data['createTime'] = $createtime;
     }
-    return \mod_bigbluebuttonbn\locallib\bigbluebutton::action_url('join', $data);
+    return \mod_bigbluebuttonbn\local\bigbluebutton::action_url('join', $data);
 }
 
 /**
@@ -143,7 +143,7 @@ function bigbluebuttonbn_get_join_url(
  * @return array
  */
 function bigbluebuttonbn_get_create_meeting_array($data, $metadata = array(), $pname = null, $purl = null) {
-    $createmeetingurl = \mod_bigbluebuttonbn\locallib\bigbluebutton::action_url('create', $data, $metadata);
+    $createmeetingurl = \mod_bigbluebuttonbn\local\bigbluebutton::action_url('create', $data, $metadata);
     $method = 'GET';
     $payload = null;
     if (!is_null($pname) && !is_null($purl)) {
@@ -172,7 +172,7 @@ function bigbluebuttonbn_get_create_meeting_array($data, $metadata = array(), $p
  */
 function bigbluebuttonbn_get_meeting_info_array($meetingid) {
     $xml = bigbluebuttonbn_wrap_xml_load_file(
-        \mod_bigbluebuttonbn\locallib\bigbluebutton::action_url('getMeetingInfo', ['meetingID' => $meetingid])
+        \mod_bigbluebuttonbn\local\bigbluebutton::action_url('getMeetingInfo', ['meetingID' => $meetingid])
     );
     if ($xml && $xml->returncode == 'SUCCESS' && empty($xml->messageKey)) {
         // Meeting info was returned.
@@ -273,7 +273,7 @@ function bigbluebuttonbn_get_recordings_array_fetch($meetingidsarray) {
 function bigbluebuttonbn_get_recordings_array_fetch_page($mids) {
     $recordings = array();
     // Do getRecordings is executed using a method GET (supported by all versions of BBB).
-    $url = \mod_bigbluebuttonbn\locallib\bigbluebutton::action_url('getRecordings', ['meetingID' => implode(',', $mids)]);
+    $url = \mod_bigbluebuttonbn\local\bigbluebutton::action_url('getRecordings', ['meetingID' => implode(',', $mids)]);
     $xml = bigbluebuttonbn_wrap_xml_load_file($url);
     if ($xml && $xml->returncode == 'SUCCESS' && isset($xml->recordings)) {
         // If there were meetings already created.
@@ -284,7 +284,7 @@ function bigbluebuttonbn_get_recordings_array_fetch_page($mids) {
             // Check if there is childs.
             if (isset($recordingxml->breakoutRooms->breakoutRoom)) {
                 foreach ($recordingxml->breakoutRooms->breakoutRoom as $breakoutroom) {
-                    $url = \mod_bigbluebuttonbn\locallib\bigbluebutton::action_url(
+                    $url = \mod_bigbluebuttonbn\local\bigbluebutton::action_url(
                         'getRecordings',
                         ['recordID' => implode(',', (array) $breakoutroom)]
                     );
@@ -356,7 +356,7 @@ function bigbluebuttonbn_get_recordings_imported_array($courseid = 0, $bigbluebu
  */
 function bigbluebuttonbn_get_default_config_xml() {
     $xml = bigbluebuttonbn_wrap_xml_load_file(
-        \mod_bigbluebuttonbn\locallib\bigbluebutton::action_url('getDefaultConfigXML')
+        \mod_bigbluebuttonbn\local\bigbluebutton::action_url('getDefaultConfigXML')
     );
     return $xml;
 }
@@ -460,7 +460,7 @@ function bigbluebuttonbn_delete_recordings($recordids) {
     $ids = explode(',', $recordids);
     foreach ($ids as $id) {
         $xml = bigbluebuttonbn_wrap_xml_load_file(
-            \mod_bigbluebuttonbn\locallib\bigbluebutton::action_url('deleteRecordings', ['recordID' => $id])
+            \mod_bigbluebuttonbn\local\bigbluebutton::action_url('deleteRecordings', ['recordID' => $id])
         );
         if ($xml && $xml->returncode != 'SUCCESS') {
             return false;
@@ -479,7 +479,7 @@ function bigbluebuttonbn_publish_recordings($recordids, $publish = 'true') {
     $ids = explode(',', $recordids);
     foreach ($ids as $id) {
         $xml = bigbluebuttonbn_wrap_xml_load_file(
-            \mod_bigbluebuttonbn\locallib\bigbluebutton::action_url('publishRecordings', ['recordID' => $id, 'publish' => $publish])
+            \mod_bigbluebuttonbn\local\bigbluebutton::action_url('publishRecordings', ['recordID' => $id, 'publish' => $publish])
         );
         if ($xml && $xml->returncode != 'SUCCESS') {
             return false;
@@ -498,7 +498,7 @@ function bigbluebuttonbn_update_recordings($recordids, $params) {
     $ids = explode(',', $recordids);
     foreach ($ids as $id) {
         $xml = bigbluebuttonbn_wrap_xml_load_file(
-            \mod_bigbluebuttonbn\locallib\bigbluebutton::action_url('updateRecordings', ['recordID' => $id] + (array) $params)
+            \mod_bigbluebuttonbn\local\bigbluebutton::action_url('updateRecordings', ['recordID' => $id] + (array) $params)
         );
         if ($xml && $xml->returncode != 'SUCCESS') {
             return false;
@@ -515,7 +515,7 @@ function bigbluebuttonbn_update_recordings($recordids, $params) {
  */
 function bigbluebuttonbn_end_meeting($meetingid, $modpw) {
     $xml = bigbluebuttonbn_wrap_xml_load_file(
-        \mod_bigbluebuttonbn\locallib\bigbluebutton::action_url('end', ['meetingID' => $meetingid, 'password' => $modpw])
+        \mod_bigbluebuttonbn\local\bigbluebutton::action_url('end', ['meetingID' => $meetingid, 'password' => $modpw])
     );
     if ($xml) {
         // If the xml packet returned failure it displays the message to the user.
@@ -532,7 +532,7 @@ function bigbluebuttonbn_end_meeting($meetingid, $modpw) {
  */
 function bigbluebuttonbn_get_server_version() {
     $xml = bigbluebuttonbn_wrap_xml_load_file(
-        \mod_bigbluebuttonbn\locallib\bigbluebutton::action_url()
+        \mod_bigbluebuttonbn\local\bigbluebutton::action_url()
     );
     if ($xml && $xml->returncode == 'SUCCESS') {
         return $xml->version;
@@ -847,7 +847,7 @@ function bigbluebuttonbn_get_participant_list_default($context, $ownerid = null)
         'selectionid' => 'all',
         'role' => BIGBLUEBUTTONBN_ROLE_VIEWER,
     );
-    $defaultrules = explode(',', \mod_bigbluebuttonbn\locallib\config::get('participant_moderator_default'));
+    $defaultrules = explode(',', \mod_bigbluebuttonbn\local\config::get('participant_moderator_default'));
     foreach ($defaultrules as $defaultrule) {
         if ($defaultrule == '0') {
             if (!empty($ownerid) && is_enrolled($context, $ownerid)) {
@@ -1035,7 +1035,7 @@ function bigbluebuttonbn_get_duration($closingtime) {
     $now = time();
     if ($closingtime > 0 && $now < $closingtime) {
         $duration = ceil(($closingtime - $now) / 60);
-        $compensationtime = intval((int) \mod_bigbluebuttonbn\locallib\config::get('scheduled_duration_compensation'));
+        $compensationtime = intval((int) \mod_bigbluebuttonbn\local\config::get('scheduled_duration_compensation'));
         $duration = intval($duration) + $compensationtime;
     }
     return $duration;
@@ -1237,7 +1237,7 @@ function bigbluebuttonbn_participant_joined($meetingid, $ismoderator) {
  * @return array
  */
 function bigbluebuttonbn_get_meeting_info($meetingid, $updatecache = false) {
-    $cachettl = (int) \mod_bigbluebuttonbn\locallib\config::get('waitformoderator_cache_ttl');
+    $cachettl = (int) \mod_bigbluebuttonbn\local\config::get('waitformoderator_cache_ttl');
     $cache = cache::make_from_params(cache_store::MODE_APPLICATION, 'mod_bigbluebuttonbn', 'meetings_cache');
     $result = $cache->get($meetingid);
     $now = time();
@@ -1247,7 +1247,7 @@ function bigbluebuttonbn_get_meeting_info($meetingid, $updatecache = false) {
     }
     // Ping again and refresh the cache.
     $meetinginfo = (array) bigbluebuttonbn_wrap_xml_load_file(
-        \mod_bigbluebuttonbn\locallib\bigbluebutton::action_url('getMeetingInfo', ['meetingID' => $meetingid])
+        \mod_bigbluebuttonbn\local\bigbluebutton::action_url('getMeetingInfo', ['meetingID' => $meetingid])
     );
     $cache->set($meetingid, array('creation_time' => time(), 'meeting_info' => json_encode($meetinginfo)));
     return $meetinginfo;
@@ -1357,7 +1357,7 @@ function bigbluebuttonbn_protect_recording_imported($id, $protect = true) {
  * @return object
  */
 function bigbluebuttonbn_set_config_xml($meetingid, $configxml) {
-    $urldefaultconfig = \mod_bigbluebuttonbn\locallib\config::get('server_url') . 'api/setConfigXML?';
+    $urldefaultconfig = \mod_bigbluebuttonbn\local\config::get('server_url') . 'api/setConfigXML?';
     $configxmlparams = bigbluebuttonbn_set_config_xml_params($meetingid, $configxml);
     $xml = bigbluebuttonbn_wrap_xml_load_file(
         $urldefaultconfig,
@@ -1378,7 +1378,7 @@ function bigbluebuttonbn_set_config_xml($meetingid, $configxml) {
  */
 function bigbluebuttonbn_set_config_xml_params($meetingid, $configxml) {
     $params = 'configXML=' . urlencode($configxml) . '&meetingID=' . urlencode($meetingid);
-    $sharedsecret = \mod_bigbluebuttonbn\locallib\config::get('shared_secret');
+    $sharedsecret = \mod_bigbluebuttonbn\local\config::get('shared_secret');
     $configxmlparams = $params . '&checksum=' . sha1('setConfigXML' . $params . $sharedsecret);
     return $configxmlparams;
 }
@@ -1743,7 +1743,7 @@ function bigbluebuttonbn_get_recording_type_text($playbacktype) {
  */
 function bigbluebuttonbn_is_valid_resource($url) {
     $urlhost = parse_url($url, PHP_URL_HOST);
-    $serverurlhost = parse_url(\mod_bigbluebuttonbn\locallib\config::get('server_url'), PHP_URL_HOST);
+    $serverurlhost = parse_url(\mod_bigbluebuttonbn\local\config::get('server_url'), PHP_URL_HOST);
     // Skip validation when the recording URL host is the same as the configured BBB server.
     if ($urlhost == $serverurlhost) {
         return true;
@@ -1883,7 +1883,7 @@ function bigbluebuttonbn_actionbar_render_button($recording, $data) {
     }
     $id = 'recording-' . $target . '-' . $recording['recordID'];
     $onclick = 'M.mod_bigbluebuttonbn.recordings.recording' . ucfirst($data['action']) . '(this); return false;';
-    if ((boolean) \mod_bigbluebuttonbn\locallib\config::get('recording_icons_enabled')) {
+    if ((boolean) \mod_bigbluebuttonbn\local\config::get('recording_icons_enabled')) {
         // With icon for $manageaction.
         $iconattributes = array('id' => $id, 'class' => 'iconsmall');
         $linkattributes = array(
@@ -2095,7 +2095,7 @@ function bigbluebuttonbn_include_recording_table_row($bbbsession, $recording) {
  * @return void
  */
 function bigbluebuttonbn_send_notification_recording_ready($bigbluebuttonbn) {
-    \mod_bigbluebuttonbn\locallib\notifier::notify_recording_ready($bigbluebuttonbn);
+    \mod_bigbluebuttonbn\local\notifier::notify_recording_ready($bigbluebuttonbn);
 }
 
 /**
@@ -2181,10 +2181,10 @@ function bigbluebuttonbn_completion_update_state($bigbluebuttonbn, $userid) {
  * @return boolean
  */
 function bigbluebuttonbn_is_bn_server() {
-    if (\mod_bigbluebuttonbn\locallib\config::get('bn_server')) {
+    if (\mod_bigbluebuttonbn\local\config::get('bn_server')) {
         return true;
     }
-    $parsedurl = parse_url(\mod_bigbluebuttonbn\locallib\config::get('server_url'));
+    $parsedurl = parse_url(\mod_bigbluebuttonbn\local\config::get('server_url'));
     if (!isset($parsedurl['host'])) {
         return false;
     }
@@ -2523,16 +2523,16 @@ function bigbluebuttonbn_get_enabled_features($typeprofiles, $type = null) {
     $enabledfeatures['showroom'] = (in_array('all', $features) || in_array('showroom', $features));
     // Evaluates if recordings are enabled for the Moodle site.
     $enabledfeatures['showrecordings'] = false;
-    if (\mod_bigbluebuttonbn\locallib\config::recordings_enabled()) {
+    if (\mod_bigbluebuttonbn\local\config::recordings_enabled()) {
         $enabledfeatures['showrecordings'] = (in_array('all', $features) || in_array('showrecordings', $features));
     }
     $enabledfeatures['importrecordings'] = false;
-    if (\mod_bigbluebuttonbn\locallib\config::importrecordings_enabled()) {
+    if (\mod_bigbluebuttonbn\local\config::importrecordings_enabled()) {
         $enabledfeatures['importrecordings'] = (in_array('all', $features) || in_array('importrecordings', $features));
     }
     // Evaluates if clienttype is enabled for the Moodle site.
     $enabledfeatures['clienttype'] = false;
-    if (\mod_bigbluebuttonbn\locallib\config::clienttype_enabled()) {
+    if (\mod_bigbluebuttonbn\local\config::clienttype_enabled()) {
         $enabledfeatures['clienttype'] = (in_array('all', $features) || in_array('clienttype', $features));
     }
     return $enabledfeatures;
@@ -3016,7 +3016,7 @@ function bigbluebuttonbn_settings_clienttype(&$renderer) {
             $renderer->render_group_element_checkbox('clienttype_editable', 0)
         );
         // Web Client default.
-        $default = intval((int) \mod_bigbluebuttonbn\locallib\config::get('clienttype_default'));
+        $default = intval((int) \mod_bigbluebuttonbn\local\config::get('clienttype_default'));
         $choices = array(BIGBLUEBUTTON_CLIENTTYPE_FLASH => get_string('mod_form_block_clienttype_flash', 'bigbluebuttonbn'),
             BIGBLUEBUTTON_CLIENTTYPE_HTML5 => get_string('mod_form_block_clienttype_html5', 'bigbluebuttonbn'));
         $renderer->render_group_element(
@@ -3547,7 +3547,7 @@ function bigbluebuttonbn_instance_ownerid($bigbluebuttonbn) {
  * @return boolean
  */
 function bigbluebuttonbn_has_html5_client() {
-    $checkurl = \mod_bigbluebuttonbn\locallib\bigbluebutton::root() . "html5client/check";
+    $checkurl = \mod_bigbluebuttonbn\local\bigbluebutton::root() . "html5client/check";
     $curlinfo = bigbluebuttonbn_wrap_xml_load_file_curl_request($checkurl, 'HEAD');
     return (isset($curlinfo['http_code']) && $curlinfo['http_code'] == 200);
 }
@@ -3644,7 +3644,7 @@ function bigbluebuttonbn_create_meeting_metadata(&$bbbsession) {
         'bbb-recording-tags' => bigbluebuttonbn_get_tags($bbbsession['cm']->id), // Same as $id.
     ];
     // Special metadata for recording processing.
-    if ((boolean) \mod_bigbluebuttonbn\locallib\config::get('recordingstatus_enabled')) {
+    if ((boolean) \mod_bigbluebuttonbn\local\config::get('recordingstatus_enabled')) {
         $metadata["bn-recording-status"] = json_encode(
             array(
                 'email' => array('"' . fullname($USER) . '" <' . $USER->email . '>'),
@@ -3652,10 +3652,10 @@ function bigbluebuttonbn_create_meeting_metadata(&$bbbsession) {
             )
         );
     }
-    if ((boolean) \mod_bigbluebuttonbn\locallib\config::get('recordingready_enabled')) {
+    if ((boolean) \mod_bigbluebuttonbn\local\config::get('recordingready_enabled')) {
         $metadata['bn-recording-ready-url'] = $bbbsession['recordingReadyURL'];
     }
-    if ((boolean) \mod_bigbluebuttonbn\locallib\config::get('meetingevents_enabled')) {
+    if ((boolean) \mod_bigbluebuttonbn\local\config::get('meetingevents_enabled')) {
         $metadata['analytics-callback-url'] = $bbbsession['meetingEventsURL'];
     }
     return $metadata;

--- a/mod_form.php
+++ b/mod_form.php
@@ -58,7 +58,7 @@ class mod_bigbluebuttonbn_mod_form extends moodleform_mod {
             $bigbluebuttonbn = $DB->get_record('bigbluebuttonbn', array('id' => $this->current->id), '*', MUST_EXIST);
         }
         // UI configuration options.
-        $cfg = \mod_bigbluebuttonbn\locallib\config::get_options();
+        $cfg = \mod_bigbluebuttonbn\local\config::get_options();
 
         $jsvars = array();
 
@@ -182,7 +182,7 @@ class mod_bigbluebuttonbn_mod_form extends moodleform_mod {
      */
     public function add_completion_rules() {
         $mform = $this->_form;
-        if (!(boolean)\mod_bigbluebuttonbn\locallib\config::get('meetingevents_enabled')) {
+        if (!(boolean)\mod_bigbluebuttonbn\local\config::get('meetingevents_enabled')) {
             return [];
         }
 
@@ -259,7 +259,7 @@ class mod_bigbluebuttonbn_mod_form extends moodleform_mod {
      * @return void
      */
     private function bigbluebuttonbn_mform_add_block_profiles(&$mform, $profiles) {
-        if ((boolean)\mod_bigbluebuttonbn\locallib\config::recordings_enabled()) {
+        if ((boolean)\mod_bigbluebuttonbn\local\config::recordings_enabled()) {
             $mform->addElement('select', 'type', get_string('mod_form_field_instanceprofiles', 'bigbluebuttonbn'),
                 bigbluebuttonbn_get_instance_profiles_array($profiles),
                 array('onchange' => 'M.mod_bigbluebuttonbn.modform.updateInstanceTypeProfile(this);'));

--- a/settings.php
+++ b/settings.php
@@ -36,7 +36,7 @@ if ($hassiteconfig) {
     // Renders general settings.
     bigbluebuttonbn_settings_general($renderer);
     // Evaluates if recordings are enabled for the Moodle site.
-    if (\mod_bigbluebuttonbn\locallib\config::recordings_enabled()) {
+    if (\mod_bigbluebuttonbn\local\config::recordings_enabled()) {
         // Renders settings for record feature.
         bigbluebuttonbn_settings_record($renderer);
         // Renders settings for import recordings.

--- a/view.php
+++ b/view.php
@@ -55,7 +55,7 @@ $bbbsession['coursename'] = $course->fullname;
 $bbbsession['cm'] = $cm;
 $bbbsession['bigbluebuttonbn'] = $bigbluebuttonbn;
 // In locallib.
-mod_bigbluebuttonbn\locallib\bigbluebutton::view_bbbsession_set($PAGE->context, $bbbsession);
+mod_bigbluebuttonbn\local\bigbluebutton::view_bbbsession_set($PAGE->context, $bbbsession);
 
 // Validates if the BigBlueButton server is working.
 $serverversion = bigbluebuttonbn_get_server_version();  // In locallib.

--- a/viewlib.php
+++ b/viewlib.php
@@ -106,7 +106,7 @@ function bigbluebuttonbn_view_render(&$bbbsession, $activity) {
     }
     $typeprofiles = bigbluebuttonbn_get_instance_type_profiles();
     $enabledfeatures = bigbluebuttonbn_get_enabled_features($typeprofiles, $type);
-    $pinginterval = (int)\mod_bigbluebuttonbn\locallib\config::get('waitformoderator_ping_interval') * 1000;
+    $pinginterval = (int)\mod_bigbluebuttonbn\local\config::get('waitformoderator_ping_interval') * 1000;
     // JavaScript for locales.
     $PAGE->requires->strings_for_js(array_keys(bigbluebuttonbn_get_strings_for_js()), 'bigbluebuttonbn');
     // JavaScript variables.
@@ -185,7 +185,7 @@ function bigbluebuttonbn_view_warning_shown($bbbsession) {
     if (is_siteadmin($bbbsession['userID'])) {
         return true;
     }
-    $generalwarningroles = explode(',', \mod_bigbluebuttonbn\locallib\config::get('general_warning_roles'));
+    $generalwarningroles = explode(',', \mod_bigbluebuttonbn\local\config::get('general_warning_roles'));
     $userroles = bigbluebuttonbn_get_user_roles($bbbsession['context'], $bbbsession['userID']);
     foreach ($userroles as $userrole) {
         if (in_array($userrole->shortname, $generalwarningroles)) {
@@ -339,7 +339,7 @@ function bigbluebuttonbn_view_warning_default_server(&$bbbsession) {
     if (!is_siteadmin($bbbsession['userID'])) {
         return '';
     }
-    if (bbb_constants::BIGBLUEBUTTONBN_DEFAULT_SERVER_URL != \mod_bigbluebuttonbn\locallib\config::get('server_url')) {
+    if (bbb_constants::BIGBLUEBUTTONBN_DEFAULT_SERVER_URL != \mod_bigbluebuttonbn\local\config::get('server_url')) {
         return '';
     }
     return bigbluebuttonbn_render_warning(get_string('view_warning_default_server', 'bigbluebuttonbn'), 'warning');
@@ -357,10 +357,10 @@ function bigbluebuttonbn_view_warning_general(&$bbbsession) {
         return '';
     }
     return bigbluebuttonbn_render_warning(
-        (string)\mod_bigbluebuttonbn\locallib\config::get('general_warning_message'),
-        (string)\mod_bigbluebuttonbn\locallib\config::get('general_warning_box_type'),
-        (string)\mod_bigbluebuttonbn\locallib\config::get('general_warning_button_href'),
-        (string)\mod_bigbluebuttonbn\locallib\config::get('general_warning_button_text'),
-        (string)\mod_bigbluebuttonbn\locallib\config::get('general_warning_button_class')
+        (string)\mod_bigbluebuttonbn\local\config::get('general_warning_message'),
+        (string)\mod_bigbluebuttonbn\local\config::get('general_warning_box_type'),
+        (string)\mod_bigbluebuttonbn\local\config::get('general_warning_button_href'),
+        (string)\mod_bigbluebuttonbn\local\config::get('general_warning_button_text'),
+        (string)\mod_bigbluebuttonbn\local\config::get('general_warning_button_class')
     );
 }


### PR DESCRIPTION
Fix use of Level 2 Namespace
    
* Move bigbluebutton, config, mobileview and notifier class into the  local namespace

This merge has to happen after CONTRIB-8400 and CONTRIB-8392 as it depends on some changes made in these tickets.