### PR TITLE
CONTRIB-8471: Fix issue with direct access to a group

### DIFF
--- a/bbb_view.php
+++ b/bbb_view.php
@@ -23,6 +23,8 @@
  * @author    Jesus Federico  (jesus [at] blindsidenetworks [dt] com)
  */
 
+use mod_bigbluebuttonbn\locallib\bigbluebutton;
+
 require_once(dirname(dirname(dirname(__FILE__))).'/config.php');
 require_once(dirname(__FILE__).'/locallib.php');
 
@@ -90,15 +92,21 @@ if ($timeline || $index) {
 
     // Check group.
     if ($group >= 0) {
-        $bbbsession['group'] = $group;
-        $groupname = get_string('allparticipants');
-        if ($bbbsession['group'] != 0) {
-            $groupname = groups_get_group_name($bbbsession['group']);
-        }
+        global $USER;
+        // CONTRIB-8471: prevent user from accessing the activity if not member of the group.
+        if (bigbluebutton::user_can_access_groups($group, $USER, $course, $cm)) {
+            $bbbsession['group'] = $group;
+            $groupname = get_string('allparticipants');
+            if ($bbbsession['group'] != 0) {
+                $groupname = groups_get_group_name($bbbsession['group']);
+            }
 
-        // Assign group default values.
-        $bbbsession['meetingid'] .= '['.$bbbsession['group'].']';
-        $bbbsession['meetingname'] .= ' ('.$groupname.')';
+            // Assign group default values.
+            $bbbsession['meetingid'] .= '[' . $bbbsession['group'] . ']';
+            $bbbsession['meetingname'] .= ' (' . $groupname . ')';
+        } else {
+            print_error('invalidaccess');
+        }
     }
 
     // Initialize session variable used across views.

--- a/classes/locallib/bigbluebutton.php
+++ b/classes/locallib/bigbluebutton.php
@@ -25,6 +25,7 @@
 
 namespace mod_bigbluebuttonbn\locallib;
 
+use context_course;
 use context_module;
 
 defined('MOODLE_INTERNAL') || die();
@@ -289,5 +290,34 @@ class bigbluebutton {
             }
         }
         return $canjoin;
+    }
+
+    /**
+     * Check if a user has access to a given group.
+     *
+     * @param $groupid
+     * @param $user
+     * @param $course
+     * @return bool
+     * @throws \coding_exception
+     */
+    public static function user_can_access_groups($groupid, $user, $course, $cm) {
+        $groupmode = groups_get_activity_groupmode($cm);
+        $context = context_course::instance($course->id);
+        $aag = has_capability('moodle/site:accessallgroups', $context, $user);
+        if ($aag) {
+            return true;
+        }
+        if ($groupmode == VISIBLEGROUPS or $aag) {
+            $allowedgroups = groups_get_all_groups($course->id, $user->id, $course->defaultgroupingid);
+        } else {
+            $allowedgroups = groups_get_all_groups($course->id, $user->id, $course->defaultgroupingid);
+        }
+        foreach ($allowedgroups as $g) {
+            if ($g->id == $groupid) {
+                return true;
+            }
+        }
+        return false;
     }
 }


### PR DESCRIPTION
When used added the right parameter access was granted without a check. 
We now check if the user belongs to the group before granting access.

**Note**: seems that a phpunit test is failing due to deprecation on 3.11. We would need to create a new ticket for this.