### PR TITLE
CONTRIB-8536: non moderator should not see "End meeting" button

### DIFF
--- a/classes/external/meeting_info.php
+++ b/classes/external/meeting_info.php
@@ -174,6 +174,7 @@ class meeting_info extends external_api {
         if (!empty($bbbsession['group'])) {
             $bbbinfo->group = $bbbsession['group'];
         }
+        $bbbinfo->ismoderator = $ismoderator;
         return (array) $bbbinfo;
     }
 
@@ -202,6 +203,7 @@ class meeting_info extends external_api {
                 'moderatorplural' => new external_value(PARAM_BOOL, 'Several moderators ?', VALUE_OPTIONAL),
                 'participantplural' => new external_value(PARAM_BOOL, 'Several participants ?', VALUE_OPTIONAL),
                 'canjoin' => new external_value(PARAM_BOOL, 'Can join'),
+                'ismoderator' => new external_value(PARAM_BOOL, 'Is moderator'),
                 'presentation' => new \external_multiple_structure(
                     new external_single_structure(
                         [

--- a/templates/room_view.mustache
+++ b/templates/room_view.mustache
@@ -91,12 +91,14 @@
                    data-cm-id="{{cmid}}"
                    {{#group}}data-group-id="{{group}}"{{/group}}
                    class="btn btn-primary bbb-btn-action  {{^canjoin}}d-none{{/canjoin}}">
+            {{#ismoderator}}
             <input id="end_button_input"
                    type="button"
                    data-bbb-id="{{bigbluebuttonbnid}}"
                    data-meeting-id="{{meetingid}}"
                    value="{{#str}}view_conference_action_end, mod_bigbluebuttonbn{{/str}}"
                    class="btn btn-secondary bbb-btn-action  {{#statusopen}}d-none{{/statusopen}}">
+            {{/ismoderator}}
         </div>
     </div>
 </div>


### PR DESCRIPTION
The new implementation show the End meeting button even if the user is not a moderator.
A click on the button is followed up with an error message but the button in fact should be completely hidden.