### PR TITLE
CONTRIB-8528: Error when viewing an activity with a set date

### DIFF
--- a/classes/external/get_recordings.php
+++ b/classes/external/get_recordings.php
@@ -227,7 +227,7 @@ class get_recordings extends external_api {
         return new external_single_structure([
             'status' => new external_value(PARAM_BOOL, 'Whether the fetch was successful'),
             'tabledata' => new external_single_structure([
-                'activity' => new external_value(PARAM_ALPHA),
+                'activity' => new external_value(PARAM_ALPHANUMEXT),
                 'ping_interval' => new external_value(PARAM_INT),
                 'locale' => new external_value(PARAM_TEXT),
                 'profile_features' => new external_multiple_structure(new external_value(PARAM_TEXT)),

--- a/classes/external/meeting_info.php
+++ b/classes/external/meeting_info.php
@@ -132,7 +132,7 @@ class meeting_info extends external_api {
         }
         $activitystatus = bigbluebutton::bigbluebuttonbn_view_session_config($bbbsession, $bbbsession['bigbluebuttonbn']->id);
         $bbbinfo->statusrunning = $running;
-        $bbbinfo->statusclosed = ($activitystatus == 'closed');
+        $bbbinfo->statusclosed = ($activitystatus == 'ended');
         if (!$running) {
             $bbbinfo->statusopen = ($activitystatus == 'open');
         }
@@ -164,12 +164,15 @@ class meeting_info extends external_api {
         $bbbinfo->bigbluebuttonbnid = $bbbsession['bigbluebuttonbn']->id;
         $bbbinfo->cmid = $bbbsession['cm']->id;
         $bbbinfo->userlimit = $bbbsession['userlimit'];
-        $presentation = $bbbsession['presentation']['url'] ? [
-            'url' => $bbbsession['presentation']['url'],
-            'iconname' => $bbbsession['presentation']['icon'],
-            'icondesc' => $bbbsession['presentation']['mimetype_description'],
-            'name' => $bbbsession['presentation']['name'],
-        ] : [];
+        $presentation = [];
+        if (!empty($bbbsession['presentation']) && !empty($bbbsession['presentation']['url'])) {
+            $presentation = [
+                'url' => $bbbsession['presentation']['url'],
+                'iconname' => $bbbsession['presentation']['icon'],
+                'icondesc' => $bbbsession['presentation']['mimetype_description'],
+                'name' => $bbbsession['presentation']['name'],
+            ];
+        }
         $bbbinfo->presentation = $presentation;
         if (!empty($bbbsession['group'])) {
             $bbbinfo->group = $bbbsession['group'];


### PR DESCRIPTION
When a date was set on the BBB activity, the recording API was returning in this case a status of 'not_started' which was not compatible with the declared API value.

For this to show up the opening time should be set to a later time (i.e. currenttime + XXX).

I also corrected another warning due to the presentation not defined and checked that the behaviour when setting the date/time is right:

- We check waitformoderator
- Set a date
- And if we are not a moderator nor an admin we should not be able to see the join button
