### PR TITLE
CONTRIB-8573: Fix default welcome message

### DIFF
--- a/classes/locallib/bigbluebutton.php
+++ b/classes/locallib/bigbluebutton.php
@@ -212,7 +212,11 @@ class bigbluebutton {
         }
         $bbbsession['welcome'] = $bbbsession['bigbluebuttonbn']->welcome;
         if (!isset($bbbsession['welcome']) || $bbbsession['welcome'] == '') {
-            $bbbsession['welcome'] = get_string('mod_form_field_welcome_default', 'bigbluebuttonbn');
+            // CONTRIB-8573: default to the config and if empty, then the default string.
+            $bbbsession['welcome'] = config::get('welcome_default');
+            if (!$bbbsession['welcome']) {
+                $bbbsession['welcome'] = get_string('mod_form_field_welcome_default', 'bigbluebuttonbn');
+            }
         }
         if ($bbbsession['bigbluebuttonbn']->record) {
             // Check if is enable record all from start.


### PR DESCRIPTION
When the Welcome message is removed from the Room, the one defined by
the default string from translations is used. It should be the value
defined in the welcome_default setting