### PR TITLE
CONTRIB-8574: Add option to allow teachers to edit the welcome message

### DIFF
--- a/classes/locallib/bigbluebutton.php
+++ b/classes/locallib/bigbluebutton.php
@@ -211,7 +211,7 @@ class bigbluebutton {
             $bbbsession['recordhidebutton'] = $bbbsession['bigbluebuttonbn']->recordhidebutton;
         }
         $bbbsession['welcome'] = $bbbsession['bigbluebuttonbn']->welcome;
-        if (!isset($bbbsession['welcome']) || $bbbsession['welcome'] == '') {
+        if (!isset($bbbsession['welcome']) || $bbbsession['welcome'] == '' || !config::get('welcome_editable')) {
             // CONTRIB-8573: default to the config and if empty, then the default string.
             $bbbsession['welcome'] = config::get('welcome_default');
             if (!$bbbsession['welcome']) {

--- a/classes/locallib/config.php
+++ b/classes/locallib/config.php
@@ -247,6 +247,7 @@ class config {
                'lockonjoinconfigurable_editable' => self::get('lockonjoinconfigurable_editable'),
                'lockonjoinconfigurable_default' => self::get('lockonjoinconfigurable_default'),
                'welcome_default' => self::get('welcome_default'),
+               'welcome_editable' => self::get('welcome_editable'),
           );
     }
 }

--- a/lang/en/bigbluebuttonbn.php
+++ b/lang/en/bigbluebuttonbn.php
@@ -227,6 +227,9 @@ $string['config_muteonstart_editable'] = 'Mute on start can be edited';
 $string['config_muteonstart_editable_description'] = 'Mute on start by default can be edited when the instance is added or updated.';
 $string['config_welcome_default'] = 'Default welcome message';
 $string['config_welcome_default_description'] = 'Replaces the default message set up for the BigBlueButton server. The message can includes keywords  (%%CONFNAME%%, %%DIALNUM%%, %%CONFNUM%%) which will be substituted automatically, and also html tags like <b>...</b> or <i></i> ';
+$string['config_welcome_editable'] = 'Default welcome message is editable by teachers';
+$string['config_welcome_editable_description'] = 'Welcome message can be edited when the instance is added or updated';
+
 $string['config_default_messages'] = 'Default messages';
 $string['config_default_messages_description'] = 'Set message defaults for activities';
 

--- a/locallib.php
+++ b/locallib.php
@@ -3273,6 +3273,10 @@ function bigbluebuttonbn_settings_default_messages(&$renderer) {
         'welcome_default',
         $renderer->render_group_element_textarea('welcome_default', '', PARAM_RAW)
     );
+    $renderer->render_group_element(
+        'welcome_editable',
+        $renderer->render_group_element_checkbox('welcome_editable', 1)
+    );
 }
 
 /**

--- a/mod_form.php
+++ b/mod_form.php
@@ -300,10 +300,18 @@ class mod_bigbluebuttonbn_mod_form extends moodleform_mod {
      * @return void
      */
     private function bigbluebuttonbn_mform_add_block_room_room(&$mform, $cfg) {
-        $field = ['type' => 'textarea', 'name' => 'welcome', 'data_type' => PARAM_CLEANHTML,
-            'description_key' => 'mod_form_field_welcome'];
+        $field = ['type' => 'hidden', 'name' => 'welcome', 'data_type' => PARAM_CLEANHTML,
+            'description_key' => null, 'default' => null, 'attributes' => null];
+        if ($cfg['welcome_editable']) {
+            $field['type'] = 'textarea';
+            $field['data_type'] = PARAM_CLEANHTML;
+            $field['default'] = $cfg['welcome_default'];
+            $field['attributes'] = ['wrap' => 'virtual', 'rows' => 5, 'cols' => '60'];
+            $field['description_key'] = 'mod_form_field_welcome';
+        }
         $this->bigbluebuttonbn_mform_add_element($mform, $field['type'], $field['name'], $field['data_type'],
-            $field['description_key'], $cfg['welcome_default'], ['wrap' => 'virtual', 'rows' => 5, 'cols' => '60']);
+            $field['description_key'], $field['default'], $field['attributes']);
+
         $field = ['type' => 'hidden', 'name' => 'voicebridge', 'data_type' => PARAM_INT,
             'description_key' => null];
         if ($cfg['voicebridge_editable']) {


### PR DESCRIPTION
* Force welcome message if the new setting (welcome_editable) is not set
* If not allow to edit the welcome message in each activity