### PR TITLE
CONTRIB-8399 settings: Restructure settings page

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,7 +31,7 @@ jobs:
           - 5432:5432
 
       mariadb:
-        image: mariadb
+        image: mariadb:10.5
         env:
           MYSQL_USER: 'root'
           MYSQL_ALLOW_EMPTY_PASSWORD: "true"

--- a/classes/local/settings/settings.php
+++ b/classes/local/settings/settings.php
@@ -39,73 +39,58 @@ use mod_bigbluebuttonbn\local\bbb_constants;
 use mod_bigbluebuttonbn\local\config;
 use mod_bigbluebuttonbn\local\helpers\roles;
 
-defined('MOODLE_INTERNAL') || die();
-
-/**
- * Utility class for all files routines helper
- *
- * @package mod_bigbluebuttonbn
- * @copyright 2021 onwards, Blindside Networks Inc
- * @license   http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
- */
 class settings {
 
-    /**
-     * @var admin_setting shared value
-     */
+    /** @var admin_setting shared value */
     private $admin;
 
-    /**
-     * Module is enabled ?
-     * @var bool
-     */
+    /** @var bool Module is enabled */
     private $moduleenabled;
 
-    /**
-     * Current section
-     * @var
-     */
+    /** @var string The name of the section */
     private $section;
 
+    /** @var string The section name prefix */
+    private $sectionnameprefix = "mod_bigbluebuttonbn";
+
     /**
-     * settings constructor.
+     * Constructor for the bigbluebuttonbn settings.
      *
      * @param admin_category $admin
-     * @param object  $module
+     * @param \core\plugininfo\mod $module
      * @param string $section for the plugin setting (main setting page)
      */
-    public function __construct(&$admin, $module, $section) {
+    public function __construct(admin_category $admin, \core\plugininfo\mod $module, string $categoryname) {
         $this->moduleenabled = $module->is_enabled() === true;
         $this->admin = $admin;
+        $this->section = $categoryname;
 
-        $bbbcategorysection = $section.'cat';
-        $modbigbluebuttobnfolder = new admin_category($bbbcategorysection,
+        $modbigbluebuttobnfolder = new admin_category(
+            $categoryname,
             new lang_string('pluginname', 'mod_bigbluebuttonbn'),
-            $module->is_enabled() === false);
+            $module->is_enabled() === false
+        );
 
         $admin->add('modsettings', $modbigbluebuttobnfolder);
 
-        $mainsettings = $this->bigbluebuttonbn_settings_general($section);
-        $admin->add($bbbcategorysection, $mainsettings);
-
-        $this->section = $bbbcategorysection;
-
+        $mainsettings = $this->bigbluebuttonbn_settings_general($categoryname);
+        $admin->add($categoryname, $mainsettings);
     }
 
     /**
-     * Add the setting and lock it conditionally
+     * Add the setting and lock it conditionally.
+     *
      * @param string $name
      * @param admin_setting $item
      * @param admin_settingpage $settings
      */
-    protected function add_conditional_element($name, $item, &$settings) {
+    protected function add_conditional_element(string $name, admin_setting $item, admin_settingpage $settings): void {
         global $CFG;
         if (isset($CFG->bigbluebuttonbn) && isset($CFG->bigbluebuttonbn[$name])) {
             if ($item->config_read($item->name)) {
-                // A value has been set, we can safely ommit the setting and it won't interfere with installation
+                // A value has been set, we can safely omit the setting and it won't interfere with installation
                 // process.
                 // The idea behind it is to hide values from end-users in case we use multitenancy for example.
-                // TODO: check if this approach is valid.
                 return;
             }
         }
@@ -115,14 +100,16 @@ class settings {
     /**
      * Helper function renders general settings if the feature is enabled.
      *
-     * @param string $sectioname
-     *
      * @return admin_settingpage
      * @throws \coding_exception
      */
-    public function bigbluebuttonbn_settings_general($sectioname) {
-        $settingsgeneral = new admin_settingpage($sectioname, get_string('config_general', 'bigbluebuttonbn'),
-            'moodle/site:config', !((boolean) validator::section_general_shown()) && ($this->moduleenabled));
+    public function bigbluebuttonbn_settings_general(): admin_settingpage {
+        $settingsgeneral = new admin_settingpage(
+            "{$this->sectionnameprefix}_general",
+            get_string('config_general', 'bigbluebuttonbn'),
+            'moodle/site:config',
+            !((boolean) validator::section_general_shown()) && ($this->moduleenabled)
+        );
         if ($this->admin->fulltree) {
             // Configuration for BigBlueButton.
             $item = new admin_setting_heading('bigbluebuttonbn_config_general',
@@ -168,13 +155,16 @@ class settings {
 
     /**
      * Helper function renders record settings if the feature is enabled.
-     *
-     * @return void
      */
-    public function bigbluebuttonbn_settings_record() {
+    public function bigbluebuttonbn_settings_record(): void {
         // Configuration for 'recording' feature.
-        $recordingsetting = new admin_settingpage('recording', get_string('config_recording', 'bigbluebuttonbn'),
-            'moodle/site:config', !((boolean) validator::section_record_meeting_shown()) && ($this->moduleenabled));
+        $recordingsetting = new admin_settingpage(
+            "{$this->sectionnameprefix}_recording",
+            get_string('config_recording', 'bigbluebuttonbn'),
+            'moodle/site:config',
+            !((boolean) validator::section_record_meeting_shown()) && ($this->moduleenabled)
+        );
+
         if ($this->admin->fulltree) {
             $item = new admin_setting_heading('bigbluebuttonbn_config_recording',
                 '',
@@ -251,16 +241,16 @@ class settings {
 
     /**
      * Helper function renders import recording settings if the feature is enabled.
-     *
-     *
-     * @return void
-     * @throws \coding_exception
      */
-    public function bigbluebuttonbn_settings_importrecordings() {
+    public function bigbluebuttonbn_settings_importrecordings(): void {
         // Configuration for 'import recordings' feature.
-        $importrecordingsettings = new admin_settingpage('importrecordings',
+        $importrecordingsettings = new admin_settingpage(
+            "{$this->sectionnameprefix}_importrecording",
             get_string('config_importrecordings', 'bigbluebuttonbn'),
-            'moodle/site:config', !((boolean) validator::section_import_recordings_shown()) && ($this->moduleenabled));
+            'moodle/site:config',
+            !((boolean) validator::section_import_recordings_shown()) && ($this->moduleenabled)
+        );
+
         if ($this->admin->fulltree) {
             $item = new admin_setting_heading('bigbluebuttonbn_config_importrecordings',
                 '',
@@ -290,15 +280,16 @@ class settings {
 
     /**
      * Helper function renders show recording settings if the feature is enabled.
-     *
-     *
-     * @return void
      */
-    public function bigbluebuttonbn_settings_showrecordings() {
+    public function bigbluebuttonbn_settings_showrecordings(): void {
         // Configuration for 'show recordings' feature.
-        $showrecordingsettings = new admin_settingpage('showrecordings',
+        $showrecordingsettings = new admin_settingpage(
+            "{$this->sectionnameprefix}_showrecordings",
             get_string('config_recordings', 'bigbluebuttonbn'),
-            'moodle/site:config', !((boolean) validator::section_show_recordings_shown()) && ($this->moduleenabled));
+            'moodle/site:config',
+            !((boolean) validator::section_show_recordings_shown()) && ($this->moduleenabled)
+        );
+
         if ($this->admin->fulltree) {
             $item = new admin_setting_heading('bigbluebuttonbn_config_recordings',
                 '',
@@ -400,15 +391,16 @@ class settings {
 
     /**
      * Helper function renders wait for moderator settings if the feature is enabled.
-     *
-     *
-     * @return void
      */
-    public function bigbluebuttonbn_settings_waitmoderator() {
+    public function bigbluebuttonbn_settings_waitmoderator(): void {
         // Configuration for wait for moderator feature.
-        $waitmoderatorsettings = new admin_settingpage('waitformoderator',
+        $waitmoderatorsettings = new admin_settingpage(
+            "{$this->sectionnameprefix}_waitformoderator",
             get_string('config_waitformoderator', 'bigbluebuttonbn'),
-            'moodle/site:config', !((boolean) validator::section_wait_moderator_shown()) && ($this->moduleenabled));
+            'moodle/site:config',
+            !((boolean) validator::section_wait_moderator_shown()) && ($this->moduleenabled)
+        );
+
         if ($this->admin->fulltree) {
             $item = new admin_setting_heading('bigbluebuttonbn_config_waitformoderator',
                 '',
@@ -456,16 +448,16 @@ class settings {
 
     /**
      * Helper function renders static voice bridge settings if the feature is enabled.
-     *
-     *
-     * @return void
      */
-    public function bigbluebuttonbn_settings_voicebridge() {
+    public function bigbluebuttonbn_settings_voicebridge(): void {
         // Configuration for "static voice bridge" feature.
-        $voicebridgesettings = new admin_settingpage('voicebridge',
+        $voicebridgesettings = new admin_settingpage(
+            "{$this->sectionnameprefix}_voicebridge",
             get_string('config_voicebridge', 'bigbluebuttonbn'),
-            'moodle/site:config', !((boolean) validator::section_static_voice_bridge_shown())
-            && ($this->moduleenabled));
+            'moodle/site:config',
+            !((boolean) validator::section_static_voice_bridge_shown()) && ($this->moduleenabled)
+        );
+
         if ($this->admin->fulltree) {
             $item = new admin_setting_heading('bigbluebuttonbn_config_voicebridge',
                 '',
@@ -486,16 +478,16 @@ class settings {
 
     /**
      * Helper function renders preuploaded presentation settings if the feature is enabled.
-     *
-     *
-     * @return void
      */
-    public function bigbluebuttonbn_settings_preupload() {
+    public function bigbluebuttonbn_settings_preupload(): void {
         // Configuration for "preupload presentation" feature.
-        $preuploadsettings = new admin_settingpage('preupload',
+        $preuploadsettings = new admin_settingpage(
+            "{$this->sectionnameprefix}_preupload",
             get_string('config_preuploadpresentation', 'bigbluebuttonbn'),
-            'moodle/site:config', !((boolean) validator::section_preupload_presentation_shown())
-            && ($this->moduleenabled));
+            'moodle/site:config',
+            !((boolean) validator::section_preupload_presentation_shown()) && ($this->moduleenabled)
+        );
+
         if ($this->admin->fulltree) {
             // This feature only works if curl is installed (but it is as now required by Moodle). The checks have been removed.
             $item = new admin_setting_heading('bigbluebuttonbn_config_preuploadpresentation',
@@ -535,15 +527,16 @@ class settings {
 
     /**
      * Helper function renders userlimit settings if the feature is enabled.
-     *
-     *
-     * @return void
      */
-    public function bigbluebuttonbn_settings_userlimit() {
-        $userlimitsettings = new admin_settingpage('userlimit',
+
+    public function bigbluebuttonbn_settings_userlimit(): void {
+        $userlimitsettings = new admin_settingpage(
+            "{$this->sectionnameprefix}_userlimit",
             get_string('config_userlimit', 'bigbluebuttonbn'),
-            'moodle/site:config', !((boolean) validator::section_user_limit_shown())
-            && ($this->moduleenabled));
+            'moodle/site:config',
+            !((boolean) validator::section_user_limit_shown()) && ($this->moduleenabled)
+        );
+
         if ($this->admin->fulltree) {
             // Configuration for "user limit" feature.
             $item = new admin_setting_heading('bigbluebuttonbn_config_userlimit',
@@ -574,16 +567,16 @@ class settings {
 
     /**
      * Helper function renders participant settings if the feature is enabled.
-     *
-     *
-     * @return void
      */
-    public function bigbluebuttonbn_settings_participants() {
+    public function bigbluebuttonbn_settings_participants(): void {
         // Configuration for defining the default role/user that will be moderator on new activities.
-        $participantsettings = new admin_settingpage('participant',
+        $participantsettings = new admin_settingpage(
+            "{$this->sectionnameprefix}_participant",
             get_string('config_participant', 'bigbluebuttonbn'),
-            'moodle/site:config', !((boolean) validator::section_moderator_default_shown())
-            && ($this->moduleenabled));
+            'moodle/site:config',
+            !((boolean) validator::section_moderator_default_shown()) && ($this->moduleenabled)
+        );
+
         if ($this->admin->fulltree) {
             $item = new admin_setting_heading('bigbluebuttonbn_config_participant',
                 '',
@@ -607,16 +600,16 @@ class settings {
 
     /**
      * Helper function renders notification settings if the feature is enabled.
-     *
-     *
-     * @return void
      */
-    public function bigbluebuttonbn_settings_notifications() {
+    public function bigbluebuttonbn_settings_notifications(): void {
         // Configuration for "send notifications" feature.
-        $notificationssettings = new admin_settingpage('bigbluebuttonmnotifications',
+        $notificationssettings = new admin_settingpage(
+            "{$this->sectionnameprefix}_notifications",
             get_string('config_sendnotifications', 'bigbluebuttonbn'),
-            'moodle/site:config', !((boolean) validator::section_send_notifications_shown())
-            && ($this->moduleenabled));
+            'moodle/site:config',
+            !((boolean) validator::section_send_notifications_shown()) && ($this->moduleenabled)
+        );
+
         if ($this->admin->fulltree) {
             $item = new admin_setting_heading('bigbluebuttonbn_config_sendnotifications',
                 '',
@@ -637,16 +630,16 @@ class settings {
 
     /**
      * Helper function renders general settings if the feature is enabled.
-     *
-     *
-     * @return void
      */
-    public function bigbluebuttonbn_settings_muteonstart() {
+    public function bigbluebuttonbn_settings_muteonstart(): void {
         // Configuration for BigBlueButton.
-        $muteonstartsetting = new admin_settingpage('muteonstart',
+        $muteonstartsetting = new admin_settingpage(
+            "{$this->sectionnameprefix}_muteonstart",
             get_string('config_muteonstart', 'bigbluebuttonbn'),
-            'moodle/site:config', !((boolean) validator::section_muteonstart_shown())
-            && ($this->moduleenabled));
+            'moodle/site:config',
+            !((boolean) validator::section_muteonstart_shown()) && ($this->moduleenabled)
+        );
+
         if ($this->admin->fulltree) {
             $item = new admin_setting_heading('bigbluebuttonbn_config_muteonstart',
                 '',
@@ -676,38 +669,41 @@ class settings {
 
     /**
      * Helper function renders general settings if the feature is enabled.
-     *
-     *
-     * @return void
      */
-    public function bigbluebuttonbn_settings_locksettings() {
-        $category = new admin_category('bigbluebuttonbnlocksettings',
+    public function bigbluebuttonbn_settings_locksettings(): void {
+        $category = new admin_category(
+            "{$this->sectionnameprefix}_locksettings",
             get_string('config_locksettings', 'bigbluebuttonbn'),
-            get_string('config_locksettings_description', 'bigbluebuttonbn'));
+            get_string('config_locksettings_description', 'bigbluebuttonbn')
+        );
+
         $this->admin->add($this->section, $category);
+
         // Configuration for various lock settings for meetings.
-        $this->bigbluebuttonbn_settings_disablecam();
-        $this->bigbluebuttonbn_settings_disablemic();
-        $this->bigbluebuttonbn_settings_disablepublicchat();
-        $this->bigbluebuttonbn_settings_disablenote();
-        $this->bigbluebuttonbn_settings_hideuserlist();
-        $this->bigbluebuttonbn_settings_lockedlayout();
-        $this->bigbluebuttonbn_settings_lockonjoin();
-        $this->bigbluebuttonbn_settings_lockonjoinconfigurable();
+        $this->bigbluebuttonbn_settings_disablecam($category);
+        $this->bigbluebuttonbn_settings_disablemic($category);
+        $this->bigbluebuttonbn_settings_disablepublicchat($category);
+        $this->bigbluebuttonbn_settings_disablenote($category);
+        $this->bigbluebuttonbn_settings_hideuserlist($category);
+        $this->bigbluebuttonbn_settings_lockedlayout($category);
+        $this->bigbluebuttonbn_settings_lockonjoin($category);
+        $this->bigbluebuttonbn_settings_lockonjoinconfigurable($category);
     }
 
     /**
      * Helper function renders general settings if the feature is enabled.
      *
-     *
-     * @return void
+     * @param admin_category $category The parent category to add to
      */
-    public function bigbluebuttonbn_settings_disablecam() {
+    public function bigbluebuttonbn_settings_disablecam(admin_category $category): void {
         // Configuration for BigBlueButton.
-        $disablecamsettings = new admin_settingpage('disablecam',
+        $disablecamsettings = new admin_settingpage(
+            "{$this->sectionnameprefix}_disablecam",
             get_string('config_disablecam_default', 'bigbluebuttonbn'),
-            'moodle/site:config', !((boolean) validator::section_disablecam_shown())
-            && ($this->moduleenabled));
+            'moodle/site:config',
+            !((boolean) validator::section_disablecam_shown()) && ($this->moduleenabled)
+        );
+
         if ($this->admin->fulltree) {
             $item = new admin_setting_configcheckbox('bigbluebuttonbn_disablecam_default',
                 get_string('config_disablecam_default', 'bigbluebuttonbn'),
@@ -728,21 +724,23 @@ class settings {
                 $disablecamsettings
             );
         }
-        $this->admin->add('bigbluebuttonbnlocksettings', $disablecamsettings);
+        $this->admin->add($category->name, $disablecamsettings);
     }
 
     /**
      * Helper function renders general settings if the feature is enabled.
      *
-     *
-     * @return void
+     * @param admin_category $category The parent category to add to
      */
-    public function bigbluebuttonbn_settings_disablemic() {
+    public function bigbluebuttonbn_settings_disablemic(admin_category $category): void {
         // Configuration for BigBlueButton.
-        $disablemicsetting = new admin_settingpage('disablemic',
+        $disablemicsetting = new admin_settingpage(
+            "{$this->sectionnameprefix}_disablemic",
             get_string('config_disablemic_default', 'bigbluebuttonbn'),
-            'moodle/site:config', !((boolean) validator::section_disablemic_shown())
-            && ($this->moduleenabled));
+            'moodle/site:config',
+            !((boolean) validator::section_disablemic_shown()) && ($this->moduleenabled)
+        );
+
         if ($this->admin->fulltree) {
             $item = new admin_setting_configcheckbox('bigbluebuttonbn_disablemic_default',
                 get_string('config_disablemic_default', 'bigbluebuttonbn'),
@@ -763,22 +761,22 @@ class settings {
                 $disablemicsetting
             );
         }
-        $this->admin->add('bigbluebuttonbnlocksettings', $disablemicsetting);
+        $this->admin->add($category->name, $disablemicsetting);
     }
 
     /**
      * Helper function renders general settings if the feature is enabled.
      *
-     *
-     * @return void
-     * @throws \coding_exception
      */
-    public function bigbluebuttonbn_settings_disableprivatechat() {
+    public function bigbluebuttonbn_settings_disableprivatechat(admin_category $category): void {
         // Configuration for BigBlueButton.
-        $disableprivatechatsetting = new admin_settingpage('disableprivatechat',
+        $disableprivatechatsetting = new admin_settingpage(
+            "{$this->sectionnameprefix}_disableprivatechat",
             get_string('config_disableprivatechat_default', 'bigbluebuttonbn'),
-            'moodle/site:config', !((boolean) validator::section_disableprivatechat_shown())
-            && ($this->moduleenabled));
+            'moodle/site:config',
+            !((boolean) validator::section_disableprivatechat_shown()) && ($this->moduleenabled)
+        );
+
         if ($this->admin->fulltree) {
             $item = new admin_setting_configcheckbox('bigbluebuttonbn_disableprivatechat_default',
                 get_string('config_disableprivatechat_default', 'bigbluebuttonbn'),
@@ -799,21 +797,23 @@ class settings {
                 $disableprivatechatsetting
             );
         }
-        $this->admin->add('bigbluebuttonbnlocksettings', $disableprivatechatsetting);
+        $this->admin->add($category->name, $disableprivatechatsetting);
     }
 
     /**
      * Helper function renders general settings if the feature is enabled.
      *
-     *
-     * @return void
+     * @param admin_category $category The parent category to add to
      */
-    public function bigbluebuttonbn_settings_disablepublicchat() {
+    public function bigbluebuttonbn_settings_disablepublicchat(admin_category $category): void {
         // Configuration for BigBlueButton.
-        $disablepublicchatsetting = new admin_settingpage('disablepublicchat',
+        $disablepublicchatsetting = new admin_settingpage(
+            "{$this->sectionnameprefix}_disablepublicchat",
             get_string('config_disableprivatechat_default', 'bigbluebuttonbn'),
-            'moodle/site:config', !((boolean) validator::section_disablepublicchat_shown())
-            && ($this->moduleenabled));
+            'moodle/site:config',
+            !((boolean) validator::section_disablepublicchat_shown()) && ($this->moduleenabled)
+        );
+
         if ($this->admin->fulltree) {
             $item = new admin_setting_configcheckbox('bigbluebuttonbn_disablepublicchat_default',
                 get_string('config_disablepublicchat_default', 'bigbluebuttonbn'),
@@ -834,21 +834,23 @@ class settings {
                 $disablepublicchatsetting
             );
         }
-        $this->admin->add('bigbluebuttonbnlocksettings', $disablepublicchatsetting);
+        $this->admin->add($category->name, $disablepublicchatsetting);
     }
 
     /**
      * Helper function renders general settings if the feature is enabled.
      *
-     *
-     * @return void
+     * @param admin_category $category The parent category to add to
      */
-    public function bigbluebuttonbn_settings_disablenote() {
+    public function bigbluebuttonbn_settings_disablenote(admin_category $category): void {
         // Configuration for BigBlueButton.
-        $disablenotesetting = new admin_settingpage('disablenote',
+        $disablenotesetting = new admin_settingpage(
+            "{$this->sectionnameprefix}_disablenote",
             get_string('config_disablenote_default', 'bigbluebuttonbn'),
-            'moodle/site:config', !((boolean) validator::section_disablenote_shown())
-            && ($this->moduleenabled));
+            'moodle/site:config',
+            !((boolean) validator::section_disablenote_shown()) && ($this->moduleenabled)
+        );
+
         if ($this->admin->fulltree) {
             $item = new admin_setting_configcheckbox('bigbluebuttonbn_disablenote_default',
                 get_string('config_disablenote_default', 'bigbluebuttonbn'),
@@ -869,21 +871,23 @@ class settings {
                 $disablenotesetting
             );
         }
-        $this->admin->add('bigbluebuttonbnlocksettings', $disablenotesetting);
+        $this->admin->add($category->name, $disablenotesetting);
     }
 
     /**
      * Helper function renders general settings if the feature is enabled.
      *
-     *
-     * @return void
+     * @param admin_category $category The parent category to add to
      */
-    public function bigbluebuttonbn_settings_hideuserlist() {
+    public function bigbluebuttonbn_settings_hideuserlist(admin_category $category): void {
         // Configuration for BigBlueButton.
-        $hideuserlistsetting = new admin_settingpage('hideuserlist',
+        $hideuserlistsetting = new admin_settingpage(
+            "{$this->sectionnameprefix}_hideuserlist",
             get_string('config_hideuserlist_default', 'bigbluebuttonbn'),
-            'moodle/site:config', !((boolean) validator::section_hideuserlist_shown())
-            && ($this->moduleenabled));
+            'moodle/site:config',
+            !((boolean) validator::section_hideuserlist_shown()) && ($this->moduleenabled)
+        );
+
         if ($this->admin->fulltree) {
             $item = new admin_setting_configcheckbox('bigbluebuttonbn_hideuserlist_default',
                 get_string('config_hideuserlist_default', 'bigbluebuttonbn'),
@@ -904,21 +908,23 @@ class settings {
                 $hideuserlistsetting
             );
         }
-        $this->admin->add('bigbluebuttonbnlocksettings', $hideuserlistsetting);
+        $this->admin->add($category->name, $hideuserlistsetting);
     }
 
     /**
      * Helper function renders general settings if the feature is enabled.
      *
-     *
-     * @return void
+     * @param admin_category $category The parent category to add to
      */
-    public function bigbluebuttonbn_settings_lockedlayout() {
+    public function bigbluebuttonbn_settings_lockedlayout(admin_category $category): void {
         // Configuration for BigBlueButton.
-        $lockedlayoutsetting = new admin_settingpage('lockedlayout',
+        $lockedlayoutsetting = new admin_settingpage(
+            "{$this->sectionnameprefix}_lockedlayout",
             get_string('config_lockedlayout_default', 'bigbluebuttonbn'),
-            'moodle/site:config', !((boolean) validator::section_lockedlayout_shown())
-            && ($this->moduleenabled));
+            'moodle/site:config',
+            !((boolean) validator::section_lockedlayout_shown()) && ($this->moduleenabled)
+        );
+
         if ($this->admin->fulltree) {
             $item = new admin_setting_configcheckbox('bigbluebuttonbn_lockedlayout_default',
                 get_string('config_lockedlayout_default', 'bigbluebuttonbn'),
@@ -939,21 +945,23 @@ class settings {
                 $lockedlayoutsetting
             );
         }
-        $this->admin->add('bigbluebuttonbnlocksettings', $lockedlayoutsetting);
+        $this->admin->add($category->name, $lockedlayoutsetting);
     }
 
     /**
      * Helper function renders general settings if the feature is enabled.
      *
-     *
-     * @return void
+     * @param admin_category $category The parent category to add to
      */
-    public function bigbluebuttonbn_settings_lockonjoin() {
+    public function bigbluebuttonbn_settings_lockonjoin(admin_category $category): void {
         // Configuration for BigBlueButton.
-        $lockonjoinsetting = new admin_settingpage('lockonjoin',
+        $lockonjoinsetting = new admin_settingpage(
+            "{$this->sectionnameprefix}_lockonjoin",
             get_string('config_lockonjoin_default', 'bigbluebuttonbn'),
-            'moodle/site:config', !((boolean) validator::section_lockonjoin_shown())
-            && ($this->moduleenabled));
+            'moodle/site:config',
+            !((boolean) validator::section_lockonjoin_shown()) && ($this->moduleenabled)
+        );
+
         if ($this->admin->fulltree) {
             if ((boolean) validator::section_lockonjoin_shown()) {
                 $item = new admin_setting_configcheckbox('bigbluebuttonbn_lockonjoin_default',
@@ -976,21 +984,23 @@ class settings {
                 );
             }
         }
-        $this->admin->add('bigbluebuttonbnlocksettings', $lockonjoinsetting);
+        $this->admin->add($category->name, $lockonjoinsetting);
     }
 
     /**
      * Helper function renders general settings if the feature is enabled.
      *
-     *
-     * @return void
+     * @param admin_category $category The parent category to add to
      */
-    public function bigbluebuttonbn_settings_lockonjoinconfigurable() {
+    public function bigbluebuttonbn_settings_lockonjoinconfigurable(admin_category $category): void {
         // Configuration for BigBlueButton.
-        $lockonjoinconfigurablesetting = new admin_settingpage('lockonjoinconfigurable',
+        $lockonjoinconfigurablesetting = new admin_settingpage(
+            "{$this->sectionnameprefix}_lockonjoinconfigurable",
             get_string('config_lockonjoinconfigurable_default', 'bigbluebuttonbn'),
-            'moodle/site:config', !((boolean) validator::section_lockonjoinconfigurable_shown())
-            && ($this->moduleenabled));
+            'moodle/site:config',
+            !((boolean) validator::section_lockonjoinconfigurable_shown()) && ($this->moduleenabled)
+        );
+
         if ($this->admin->fulltree) {
             $item = new admin_setting_configcheckbox('bigbluebuttonbn_lockonjoinconfigurable_default',
                 get_string('config_lockonjoinconfigurable_default', 'bigbluebuttonbn'),
@@ -1011,22 +1021,21 @@ class settings {
                 $lockonjoinconfigurablesetting
             );
         }
-        $this->admin->add('bigbluebuttonbnlocksettings', $lockonjoinconfigurablesetting);
+        $this->admin->add($category->name, $lockonjoinconfigurablesetting);
     }
 
     /**
      * Helper function renders extended settings if any of the features there is enabled.
-     *
-     *
-     * @return void
-     * @throws \coding_exception
      */
-    public function bigbluebuttonbn_settings_extended() {
+    public function bigbluebuttonbn_settings_extended(): void {
         // Configuration for extended capabilities.
-        $extendedcapabilitiessetting = new admin_settingpage('extendedcapabilities',
+        $extendedcapabilitiessetting = new admin_settingpage(
+            "{$this->sectionnameprefix}_extendedcapabilities",
             get_string('config_extended_capabilities', 'bigbluebuttonbn'),
-            'moodle/site:config', !((boolean) validator::section_settings_extended_shown())
-            && ($this->moduleenabled));
+            'moodle/site:config',
+            !((boolean) validator::section_settings_extended_shown()) && ($this->moduleenabled)
+        );
+
         if ($this->admin->fulltree) {
             $item = new admin_setting_heading('bigbluebuttonbn_config_extended_capabilities',
                 '',
@@ -1049,15 +1058,16 @@ class settings {
 
     /**
      * Helper function renders experimental settings if any of the features there is enabled.
-     *
-     * @return void
      */
-    public function bigbluebuttonbn_settings_experimental() {
+    public function bigbluebuttonbn_settings_experimental(): void {
         // Configuration for experimental features should go here.
-        $experimentalfeaturessetting = new admin_settingpage('experimentalfeatures',
+        $experimentalfeaturessetting = new admin_settingpage(
+            "{$this->sectionnameprefix}_experimentalfeatures",
             get_string('config_experimental_features', 'bigbluebuttonbn'),
-            'moodle/site:config', !((boolean) validator::section_settings_extended_shown())
-            && ($this->moduleenabled));
+            'moodle/site:config',
+            !((boolean) validator::section_settings_extended_shown()) && ($this->moduleenabled)
+        );
+
         if ($this->admin->fulltree) {
             $item = new admin_setting_heading('bigbluebuttonbn_config_experimental_features',
                 '',

--- a/classes/setting_validator.php
+++ b/classes/setting_validator.php
@@ -23,7 +23,7 @@
  * @author    Jesus Federico  (jesus [at] blindsidenetworks [dt] com)
  */
 
-namespace mod_bigbluebuttonbn\local\settings;
+namespace mod_bigbluebuttonbn;
 
 use mod_bigbluebuttonbn\local\bigbluebutton;
 
@@ -36,7 +36,7 @@ require_once($CFG->libdir.'/adminlib.php');
  * @copyright 2010 onwards, Blindside Networks Inc
  * @license   http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
-class validator {
+class setting_validator {
 
     /**
      * Validate if general section will be shown.

--- a/classes/settings.php
+++ b/classes/settings.php
@@ -145,33 +145,44 @@ class settings {
                 get_string('config_general_description', 'bigbluebuttonbn'));
 
             $settingsgeneral->add($item);
-            $item = new admin_setting_configtext('bigbluebuttonbn_server_url',
+            $item = new admin_setting_configtext(
+                'bigbluebuttonbn_server_url',
                 get_string('config_server_url', 'bigbluebuttonbn'),
                 get_string('config_server_url_description', 'bigbluebuttonbn'),
-                bbb_constants::BIGBLUEBUTTONBN_DEFAULT_SERVER_URL, PARAM_RAW);
+                bbb_constants::BIGBLUEBUTTONBN_DEFAULT_SERVER_URL,
+                PARAM_RAW
+            );
             $this->add_conditional_element(
                 'server_url',
                 $item,
                 $settingsgeneral
             );
-            $item = new admin_setting_configtext('bigbluebuttonbn_shared_secret',
+            $item = new admin_setting_configtext(
+                'bigbluebuttonbn_shared_secret',
                 get_string('config_shared_secret', 'bigbluebuttonbn'),
                 get_string('config_shared_secret_description', 'bigbluebuttonbn'),
-                bbb_constants::BIGBLUEBUTTONBN_DEFAULT_SHARED_SECRET, PARAM_RAW);
+                bbb_constants::BIGBLUEBUTTONBN_DEFAULT_SHARED_SECRET,
+                PARAM_RAW
+            );
             $this->add_conditional_element(
                 'shared_secret',
                 $item,
                 $settingsgeneral
             );
             $settingsgeneral->add($item);
-            $item = new admin_setting_heading('bigbluebuttonbn_config_default_messages',
+            $item = new admin_setting_heading(
+                'bigbluebuttonbn_config_default_messages',
                 get_string('config_default_messages', 'bigbluebuttonbn'),
-                get_string('config_default_messages_description', 'bigbluebuttonbn'));
+                get_string('config_default_messages_description', 'bigbluebuttonbn')
+            );
             $settingsgeneral->add($item);
-            $item = new admin_setting_configtextarea('bigbluebuttonbn_welcome_default',
+            $item = new admin_setting_configtextarea(
+                'bigbluebuttonbn_welcome_default',
                 get_string('config_welcome_default', 'bigbluebuttonbn'),
                 get_string('config_welcome_default_description', 'bigbluebuttonbn'),
-                '', PARAM_TEXT);
+                '',
+                PARAM_TEXT
+            );
             $this->add_conditional_element(
                 'welcome_default',
                 $item,
@@ -194,32 +205,40 @@ class settings {
         );
 
         if ($this->admin->fulltree) {
-            $item = new admin_setting_heading('bigbluebuttonbn_config_recording',
+            $item = new admin_setting_heading(
+                'bigbluebuttonbn_config_recording',
                 '',
-                get_string('config_recording_description', 'bigbluebuttonbn'));
+                get_string('config_recording_description', 'bigbluebuttonbn')
+            );
             $recordingsetting->add($item);
-            $item = new admin_setting_configcheckbox('bigbluebuttonbn_recording_default',
+            $item = new admin_setting_configcheckbox(
+                'bigbluebuttonbn_recording_default',
                 get_string('config_recording_default', 'bigbluebuttonbn'),
                 get_string('config_recording_default_description', 'bigbluebuttonbn'),
-                1);
+                1
+            );
             $this->add_conditional_element(
                 'recording_default',
                 $item,
                 $recordingsetting
             );
-            $item = new admin_setting_configcheckbox('bigbluebuttonbn_recording_editable',
+            $item = new admin_setting_configcheckbox(
+                'bigbluebuttonbn_recording_editable',
                 get_string('config_recording_editable', 'bigbluebuttonbn'),
                 get_string('config_recording_editable_description', 'bigbluebuttonbn'),
-                1);
+                1
+            );
             $this->add_conditional_element(
                 'recording_editable',
                 $item,
                 $recordingsetting
             );
-            $item = new admin_setting_configcheckbox('bigbluebuttonbn_recording_icons_enabled',
+            $item = new admin_setting_configcheckbox(
+                'bigbluebuttonbn_recording_icons_enabled',
                 get_string('config_recording_icons_enabled', 'bigbluebuttonbn'),
                 get_string('config_recording_icons_enabled_description', 'bigbluebuttonbn'),
-                1);
+                1
+            );
             $this->add_conditional_element(
                 'recording_icons_enabled',
                 $item,
@@ -227,37 +246,45 @@ class settings {
             );
 
             // Add recording start to load and allow/hide stop/pause.
-            $item = new admin_setting_configcheckbox('bigbluebuttonbn_recording_all_from_start_default',
+            $item = new admin_setting_configcheckbox(
+                'bigbluebuttonbn_recording_all_from_start_default',
                 get_string('config_recording_all_from_start_default', 'bigbluebuttonbn'),
                 get_string('config_recording_all_from_start_default_description', 'bigbluebuttonbn'),
-                0);
+                0
+            );
             $this->add_conditional_element(
                 'recording_all_from_start_default',
                 $item,
                 $recordingsetting
             );
-            $item = new admin_setting_configcheckbox('bigbluebuttonbn_recording_all_from_start_editable',
+            $item = new admin_setting_configcheckbox(
+                'bigbluebuttonbn_recording_all_from_start_editable',
                 get_string('config_recording_all_from_start_editable', 'bigbluebuttonbn'),
                 get_string('config_recording_all_from_start_editable_description', 'bigbluebuttonbn'),
-                0);
+                0
+            );
             $this->add_conditional_element(
                 'recording_all_from_start_editable',
                 $item,
                 $recordingsetting
             );
-            $item = new admin_setting_configcheckbox('bigbluebuttonbn_recording_hide_button_default',
+            $item = new admin_setting_configcheckbox(
+                'bigbluebuttonbn_recording_hide_button_default',
                 get_string('config_recording_hide_button_default', 'bigbluebuttonbn'),
                 get_string('config_recording_hide_button_default_description', 'bigbluebuttonbn'),
-                0);
+                0
+            );
             $this->add_conditional_element(
                 'recording_hide_button_default',
                 $item,
                 $recordingsetting
             );
-            $item = new admin_setting_configcheckbox('bigbluebuttonbn_recording_hide_button_editable',
+            $item = new admin_setting_configcheckbox(
+                'bigbluebuttonbn_recording_hide_button_editable',
                 get_string('config_recording_hide_button_editable', 'bigbluebuttonbn'),
                 get_string('config_recording_hide_button_editable_description', 'bigbluebuttonbn'),
-                0);
+                0
+            );
             $this->add_conditional_element(
                 'recording_hide_button_editable',
                 $item,
@@ -280,23 +307,29 @@ class settings {
         );
 
         if ($this->admin->fulltree) {
-            $item = new admin_setting_heading('bigbluebuttonbn_config_importrecordings',
+            $item = new admin_setting_heading(
+                'bigbluebuttonbn_config_importrecordings',
                 '',
-                get_string('config_importrecordings_description', 'bigbluebuttonbn'));
+                get_string('config_importrecordings_description', 'bigbluebuttonbn')
+            );
             $importrecordingsettings->add($item);
-            $item = new admin_setting_configcheckbox('bigbluebuttonbn_importrecordings_enabled',
+            $item = new admin_setting_configcheckbox(
+                'bigbluebuttonbn_importrecordings_enabled',
                 get_string('config_importrecordings_enabled', 'bigbluebuttonbn'),
                 get_string('config_importrecordings_enabled_description', 'bigbluebuttonbn'),
-                0);
+                0
+            );
             $this->add_conditional_element(
                 'importrecordings_enabled',
                 $item,
                 $importrecordingsettings
             );
-            $item = new admin_setting_configcheckbox('bigbluebuttonbn_importrecordings_from_deleted_enabled',
+            $item = new admin_setting_configcheckbox(
+                'bigbluebuttonbn_importrecordings_from_deleted_enabled',
                 get_string('config_importrecordings_from_deleted_enabled', 'bigbluebuttonbn'),
                 get_string('config_importrecordings_from_deleted_enabled_description', 'bigbluebuttonbn'),
-                0);
+                0
+            );
             $this->add_conditional_element(
                 'importrecordings_from_deleted_enabled',
                 $item,
@@ -452,41 +485,53 @@ class settings {
         );
 
         if ($this->admin->fulltree) {
-            $item = new admin_setting_heading('bigbluebuttonbn_config_waitformoderator',
+            $item = new admin_setting_heading(
+                'bigbluebuttonbn_config_waitformoderator',
                 '',
-                get_string('config_waitformoderator_description', 'bigbluebuttonbn'));
+                get_string('config_waitformoderator_description', 'bigbluebuttonbn')
+            );
             $waitmoderatorsettings->add($item);
-            $item = new admin_setting_configcheckbox('bigbluebuttonbn_waitformoderator_default',
+            $item = new admin_setting_configcheckbox(
+                'bigbluebuttonbn_waitformoderator_default',
                 get_string('config_waitformoderator_default', 'bigbluebuttonbn'),
                 get_string('config_waitformoderator_default_description', 'bigbluebuttonbn'),
-                0);
+                0
+            );
             $this->add_conditional_element(
                 'waitformoderator_default',
                 $item,
                 $waitmoderatorsettings
             );
-            $item = new admin_setting_configcheckbox('bigbluebuttonbn_waitformoderator_editable',
+            $item = new admin_setting_configcheckbox(
+                'bigbluebuttonbn_waitformoderator_editable',
                 get_string('config_waitformoderator_editable', 'bigbluebuttonbn'),
                 get_string('config_waitformoderator_editable_description', 'bigbluebuttonbn'),
-                1);
+                1
+            );
             $this->add_conditional_element(
                 'waitformoderator_editable',
                 $item,
                 $waitmoderatorsettings
             );
-            $item = new admin_setting_configtext('bigbluebuttonbn_waitformoderator_ping_interval',
+            $item = new admin_setting_configtext(
+                'bigbluebuttonbn_waitformoderator_ping_interval',
                 get_string('config_waitformoderator_ping_interval', 'bigbluebuttonbn'),
                 get_string('config_waitformoderator_ping_interval_description', 'bigbluebuttonbn'),
-                10, PARAM_INT);
+                10,
+                PARAM_INT
+            );
             $this->add_conditional_element(
                 'waitformoderator_ping_interval',
                 $item,
                 $waitmoderatorsettings
             );
-            $item = new admin_setting_configtext('bigbluebuttonbn_waitformoderator_cache_ttl',
+            $item = new admin_setting_configtext(
+                'bigbluebuttonbn_waitformoderator_cache_ttl',
                 get_string('config_waitformoderator_cache_ttl', 'bigbluebuttonbn'),
                 get_string('config_waitformoderator_cache_ttl_description', 'bigbluebuttonbn'),
-                60, PARAM_INT);
+                60,
+                PARAM_INT
+            );
             $this->add_conditional_element(
                 'waitformoderator_cache_ttl',
                 $item,
@@ -509,14 +554,18 @@ class settings {
         );
 
         if ($this->admin->fulltree) {
-            $item = new admin_setting_heading('bigbluebuttonbn_config_voicebridge',
+            $item = new admin_setting_heading(
+                'bigbluebuttonbn_config_voicebridge',
                 '',
-                get_string('config_voicebridge_description', 'bigbluebuttonbn'));
+                get_string('config_voicebridge_description', 'bigbluebuttonbn')
+            );
             $voicebridgesettings->add($item);
-            $item = new admin_setting_configcheckbox('bigbluebuttonbn_voicebridge_editable',
+            $item = new admin_setting_configcheckbox(
+                'bigbluebuttonbn_voicebridge_editable',
                 get_string('config_voicebridge_editable', 'bigbluebuttonbn'),
                 get_string('config_voicebridge_editable_description', 'bigbluebuttonbn'),
-                0);
+                0
+            );
             $this->add_conditional_element(
                 'voicebridge_editable',
                 $item,
@@ -540,15 +589,19 @@ class settings {
 
         if ($this->admin->fulltree) {
             // This feature only works if curl is installed (but it is as now required by Moodle). The checks have been removed.
-            $item = new admin_setting_heading('bigbluebuttonbn_config_preuploadpresentation',
+            $item = new admin_setting_heading(
+                'bigbluebuttonbn_config_preuploadpresentation',
                 '',
-                get_string('config_preuploadpresentation_description', 'bigbluebuttonbn'));
+                get_string('config_preuploadpresentation_description', 'bigbluebuttonbn')
+            );
             $preuploadsettings->add($item);
 
-            $item = new admin_setting_configcheckbox('bigbluebuttonbn_preuploadpresentation_enabled',
+            $item = new admin_setting_configcheckbox(
+                'bigbluebuttonbn_preuploadpresentation_enabled',
                 get_string('config_preuploadpresentation_enabled', 'bigbluebuttonbn'),
                 get_string('config_preuploadpresentation_enabled_description', 'bigbluebuttonbn'),
-                0);
+                0
+            );
             $this->add_conditional_element(
                 'preuploadpresentation_enabled',
                 $item,
@@ -562,12 +615,14 @@ class settings {
             $filemanageroptions['maxfiles'] = 1;
             $filemanageroptions['mainfile'] = true;
 
-            $filemanager = new admin_setting_configstoredfile('mod_bigbluebuttonbn/presentationdefault',
+            $filemanager = new admin_setting_configstoredfile(
+                'mod_bigbluebuttonbn/presentationdefault',
                 get_string('config_presentation_default', 'bigbluebuttonbn'),
                 get_string('config_presentation_default_description', 'bigbluebuttonbn'),
                 'presentationdefault',
                 0,
-                $filemanageroptions);
+                $filemanageroptions
+            );
 
             $preuploadsettings->add($filemanager);
         }
@@ -589,23 +644,30 @@ class settings {
 
         if ($this->admin->fulltree) {
             // Configuration for "user limit" feature.
-            $item = new admin_setting_heading('bigbluebuttonbn_config_userlimit',
+            $item = new admin_setting_heading(
+                'bigbluebuttonbn_config_userlimit',
                 '',
-                get_string('config_userlimit_description', 'bigbluebuttonbn'));
+                get_string('config_userlimit_description', 'bigbluebuttonbn')
+            );
             $userlimitsettings->add($item);
-            $item = new admin_setting_configtext('bigbluebuttonbn_userlimit_default',
+            $item = new admin_setting_configtext(
+                'bigbluebuttonbn_userlimit_default',
                 get_string('config_userlimit_default', 'bigbluebuttonbn'),
                 get_string('config_userlimit_default_description', 'bigbluebuttonbn'),
-                0, PARAM_INT);
+                0,
+                PARAM_INT
+            );
             $this->add_conditional_element(
                 'userlimit_default',
                 $item,
                 $userlimitsettings
             );
-            $item = new admin_setting_configcheckbox('bigbluebuttonbn_userlimit_editable',
+            $item = new admin_setting_configcheckbox(
+                'bigbluebuttonbn_userlimit_editable',
                 get_string('config_userlimit_editable', 'bigbluebuttonbn'),
                 get_string('config_userlimit_editable_description', 'bigbluebuttonbn'),
-                0);
+                0
+            );
             $this->add_conditional_element(
                 'userlimit_editable',
                 $item,
@@ -628,17 +690,23 @@ class settings {
         );
 
         if ($this->admin->fulltree) {
-            $item = new admin_setting_heading('bigbluebuttonbn_config_participant',
+            $item = new admin_setting_heading(
+                'bigbluebuttonbn_config_participant',
                 '',
-                get_string('config_participant_description', 'bigbluebuttonbn'));
+                get_string('config_participant_description', 'bigbluebuttonbn')
+            );
             $participantsettings->add($item);
+
             // UI for 'participants' feature.
             $roles = roles::bigbluebuttonbn_get_roles(null, false);
             $owner = array('0' => get_string('mod_form_field_participant_list_type_owner', 'bigbluebuttonbn'));
-            $item = new admin_setting_configmultiselect('bigbluebuttonbn_participant_moderator_default',
+            $item = new admin_setting_configmultiselect(
+                'bigbluebuttonbn_participant_moderator_default',
                 get_string('config_participant_moderator_default', 'bigbluebuttonbn'),
                 get_string('config_participant_moderator_default_description', 'bigbluebuttonbn'),
-                array_keys($owner), $owner + $roles);
+                array_keys($owner),
+                $owner + $roles
+            );
             $this->add_conditional_element(
                 'participant_moderator_default',
                 $item,
@@ -661,14 +729,18 @@ class settings {
         );
 
         if ($this->admin->fulltree) {
-            $item = new admin_setting_heading('bigbluebuttonbn_config_sendnotifications',
+            $item = new admin_setting_heading(
+                'bigbluebuttonbn_config_sendnotifications',
                 '',
-                get_string('config_sendnotifications_description', 'bigbluebuttonbn'));
+                get_string('config_sendnotifications_description', 'bigbluebuttonbn')
+            );
             $notificationssettings->add($item);
-            $item = new admin_setting_configcheckbox('bigbluebuttonbn_sendnotifications_enabled',
+            $item = new admin_setting_configcheckbox(
+                'bigbluebuttonbn_sendnotifications_enabled',
                 get_string('config_sendnotifications_enabled', 'bigbluebuttonbn'),
                 get_string('config_sendnotifications_enabled_description', 'bigbluebuttonbn'),
-                1);
+                1
+            );
             $this->add_conditional_element(
                 'sendnotifications_enabled',
                 $item,
@@ -691,23 +763,29 @@ class settings {
         );
 
         if ($this->admin->fulltree) {
-            $item = new admin_setting_heading('bigbluebuttonbn_config_muteonstart',
+            $item = new admin_setting_heading(
+                'bigbluebuttonbn_config_muteonstart',
                 '',
-                get_string('config_muteonstart_description', 'bigbluebuttonbn'));
+                get_string('config_muteonstart_description', 'bigbluebuttonbn')
+            );
             $muteonstartsetting->add($item);
-            $item = new admin_setting_configcheckbox('bigbluebuttonbn_muteonstart_default',
+            $item = new admin_setting_configcheckbox(
+                'bigbluebuttonbn_muteonstart_default',
                 get_string('config_muteonstart_default', 'bigbluebuttonbn'),
                 get_string('config_muteonstart_default_description', 'bigbluebuttonbn'),
-                0);
+                0
+            );
             $this->add_conditional_element(
                 'muteonstart_default',
                 $item,
                 $muteonstartsetting
             );
-            $item = new admin_setting_configcheckbox('bigbluebuttonbn_muteonstart_editable',
+            $item = new admin_setting_configcheckbox(
+                'bigbluebuttonbn_muteonstart_editable',
                 get_string('config_muteonstart_editable', 'bigbluebuttonbn'),
                 get_string('config_muteonstart_editable_description', 'bigbluebuttonbn'),
-                0);
+                0
+            );
             $this->add_conditional_element(
                 'muteonstart_editable',
                 $item,
@@ -755,19 +833,23 @@ class settings {
         );
 
         if ($this->admin->fulltree) {
-            $item = new admin_setting_configcheckbox('bigbluebuttonbn_disablecam_default',
+            $item = new admin_setting_configcheckbox(
+                'bigbluebuttonbn_disablecam_default',
                 get_string('config_disablecam_default', 'bigbluebuttonbn'),
                 get_string('config_disablecam_default_description', 'bigbluebuttonbn'),
-                0);
+                0
+            );
             $this->add_conditional_element(
                 'disablecam_default',
                 $item,
                 $disablecamsettings
             );
-            $item = new admin_setting_configcheckbox('bigbluebuttonbn_disablecam_editable',
+            $item = new admin_setting_configcheckbox(
+                'bigbluebuttonbn_disablecam_editable',
                 get_string('config_disablecam_editable', 'bigbluebuttonbn'),
                 get_string('config_disablecam_editable_description', 'bigbluebuttonbn'),
-                1);
+                1
+            );
             $this->add_conditional_element(
                 'disablecam_editable',
                 $item,
@@ -792,19 +874,23 @@ class settings {
         );
 
         if ($this->admin->fulltree) {
-            $item = new admin_setting_configcheckbox('bigbluebuttonbn_disablemic_default',
+            $item = new admin_setting_configcheckbox(
+                'bigbluebuttonbn_disablemic_default',
                 get_string('config_disablemic_default', 'bigbluebuttonbn'),
                 get_string('config_disablemic_default_description', 'bigbluebuttonbn'),
-                0);
+                0
+            );
             $this->add_conditional_element(
                 'disablemic_default',
                 $item,
                 $disablemicsetting
             );
-            $item = new admin_setting_configcheckbox('bigbluebuttonbn_disablemic_editable',
+            $item = new admin_setting_configcheckbox(
+                'bigbluebuttonbn_disablemic_editable',
                 get_string('config_disablemic_editable', 'bigbluebuttonbn'),
                 get_string('config_disablemic_editable_description', 'bigbluebuttonbn'),
-                1);
+                1
+            );
             $this->add_conditional_element(
                 'disablecam_editable',
                 $item,
@@ -829,19 +915,23 @@ class settings {
         );
 
         if ($this->admin->fulltree) {
-            $item = new admin_setting_configcheckbox('bigbluebuttonbn_disableprivatechat_default',
+            $item = new admin_setting_configcheckbox(
+                'bigbluebuttonbn_disableprivatechat_default',
                 get_string('config_disableprivatechat_default', 'bigbluebuttonbn'),
                 get_string('config_disableprivatechat_default_description', 'bigbluebuttonbn'),
-                0);
+                0
+            );
             $this->add_conditional_element(
                 'disableprivatechat_default',
                 $item,
                 $disableprivatechatsetting
             );
-            $item = new admin_setting_configcheckbox('bigbluebuttonbn_disableprivatechat_editable',
+            $item = new admin_setting_configcheckbox(
+                'bigbluebuttonbn_disableprivatechat_editable',
                 get_string('config_disableprivatechat_editable', 'bigbluebuttonbn'),
                 get_string('config_disableprivatechat_editable_description', 'bigbluebuttonbn'),
-                1);
+                1
+            );
             $this->add_conditional_element(
                 'disableprivatechat_editable',
                 $item,
@@ -903,19 +993,23 @@ class settings {
         );
 
         if ($this->admin->fulltree) {
-            $item = new admin_setting_configcheckbox('bigbluebuttonbn_disablenote_default',
+            $item = new admin_setting_configcheckbox(
+                'bigbluebuttonbn_disablenote_default',
                 get_string('config_disablenote_default', 'bigbluebuttonbn'),
                 get_string('config_disablenote_default_description', 'bigbluebuttonbn'),
-                0);
+                0
+            );
             $this->add_conditional_element(
                 'disablenote_default',
                 $item,
                 $disablenotesetting
             );
-            $item = new admin_setting_configcheckbox('bigbluebuttonbn_disablenote_editable',
+            $item = new admin_setting_configcheckbox(
+                'bigbluebuttonbn_disablenote_editable',
                 get_string('config_disablenote_editable', 'bigbluebuttonbn'),
                 get_string('config_disablenote_editable_description', 'bigbluebuttonbn'),
-                1);
+                1
+            );
             $this->add_conditional_element(
                 'disablenote_editable',
                 $item,
@@ -940,19 +1034,23 @@ class settings {
         );
 
         if ($this->admin->fulltree) {
-            $item = new admin_setting_configcheckbox('bigbluebuttonbn_hideuserlist_default',
+            $item = new admin_setting_configcheckbox(
+                'bigbluebuttonbn_hideuserlist_default',
                 get_string('config_hideuserlist_default', 'bigbluebuttonbn'),
                 get_string('config_hideuserlist_default_description', 'bigbluebuttonbn'),
-                0);
+                0
+            );
             $this->add_conditional_element(
                 'hideuserlist_default',
                 $item,
                 $hideuserlistsetting
             );
-            $item = new admin_setting_configcheckbox('bigbluebuttonbn_hideuserlist_editable',
+            $item = new admin_setting_configcheckbox(
+                'bigbluebuttonbn_hideuserlist_editable',
                 get_string('config_hideuserlist_editable', 'bigbluebuttonbn'),
                 get_string('config_hideuserlist_editable_description', 'bigbluebuttonbn'),
-                1);
+                1
+            );
             $this->add_conditional_element(
                 'hideuserlist_editable',
                 $item,
@@ -977,19 +1075,23 @@ class settings {
         );
 
         if ($this->admin->fulltree) {
-            $item = new admin_setting_configcheckbox('bigbluebuttonbn_lockedlayout_default',
+            $item = new admin_setting_configcheckbox(
+                'bigbluebuttonbn_lockedlayout_default',
                 get_string('config_lockedlayout_default', 'bigbluebuttonbn'),
                 get_string('config_lockedlayout_default_description', 'bigbluebuttonbn'),
-                0);
+                0
+            );
             $this->add_conditional_element(
                 'lockedlayout_default',
                 $item,
                 $lockedlayoutsetting
             );
-            $item = new admin_setting_configcheckbox('bigbluebuttonbn_lockedlayout_editable',
+            $item = new admin_setting_configcheckbox(
+                'bigbluebuttonbn_lockedlayout_editable',
                 get_string('config_lockedlayout_editable', 'bigbluebuttonbn'),
                 get_string('config_lockedlayout_editable_description', 'bigbluebuttonbn'),
-                1);
+                1
+            );
             $this->add_conditional_element(
                 'lockedlayout_editable',
                 $item,
@@ -1015,19 +1117,23 @@ class settings {
 
         if ($this->admin->fulltree) {
             if ((boolean) setting_validator::section_lockonjoin_shown()) {
-                $item = new admin_setting_configcheckbox('bigbluebuttonbn_lockonjoin_default',
+                $item = new admin_setting_configcheckbox(
+                    'bigbluebuttonbn_lockonjoin_default',
                     get_string('config_lockonjoin_default', 'bigbluebuttonbn'),
                     get_string('config_lockonjoin_default_description', 'bigbluebuttonbn'),
-                    0);
+                    0
+                );
                 $this->add_conditional_element(
                     'lockonjoin_default',
                     $item,
                     $lockonjoinsetting
                 );
-                $item = new admin_setting_configcheckbox('bigbluebuttonbn_lockonjoin_editable',
+                $item = new admin_setting_configcheckbox(
+                    'bigbluebuttonbn_lockonjoin_editable',
                     get_string('config_lockonjoin_editable', 'bigbluebuttonbn'),
                     get_string('config_lockonjoin_editable_description', 'bigbluebuttonbn'),
-                    1);
+                    1
+                );
                 $this->add_conditional_element(
                     'lockonjoin_editable',
                     $item,
@@ -1053,19 +1159,23 @@ class settings {
         );
 
         if ($this->admin->fulltree) {
-            $item = new admin_setting_configcheckbox('bigbluebuttonbn_lockonjoinconfigurable_default',
+            $item = new admin_setting_configcheckbox(
+                'bigbluebuttonbn_lockonjoinconfigurable_default',
                 get_string('config_lockonjoinconfigurable_default', 'bigbluebuttonbn'),
                 get_string('config_lockonjoinconfigurable_default_description', 'bigbluebuttonbn'),
-                0);
+                0
+            );
             $this->add_conditional_element(
                 'lockonjoinconfigurable_default',
                 $item,
                 $lockonjoinconfigurablesetting
             );
-            $item = new admin_setting_configcheckbox('bigbluebuttonbn_lockonjoinconfigurable_editable',
+            $item = new admin_setting_configcheckbox(
+                'bigbluebuttonbn_lockonjoinconfigurable_editable',
                 get_string('config_lockonjoinconfigurable_editable', 'bigbluebuttonbn'),
                 get_string('config_lockonjoinconfigurable_editable_description', 'bigbluebuttonbn'),
-                1);
+                1
+            );
             $this->add_conditional_element(
                 'lockonjoinconfigurable_editable',
                 $item,
@@ -1088,15 +1198,19 @@ class settings {
         );
 
         if ($this->admin->fulltree) {
-            $item = new admin_setting_heading('bigbluebuttonbn_config_extended_capabilities',
+            $item = new admin_setting_heading(
+                'bigbluebuttonbn_config_extended_capabilities',
                 '',
-                get_string('config_extended_capabilities_description', 'bigbluebuttonbn'));
+                get_string('config_extended_capabilities_description', 'bigbluebuttonbn')
+            );
             $extendedcapabilitiessetting->add($item);
             // UI for 'notify users when recording ready' feature.
-            $item = new admin_setting_configcheckbox('bigbluebuttonbn_recordingready_enabled',
+            $item = new admin_setting_configcheckbox(
+                'bigbluebuttonbn_recordingready_enabled',
                 get_string('config_recordingready_enabled', 'bigbluebuttonbn'),
                 get_string('config_recordingready_enabled_description', 'bigbluebuttonbn'),
-                0);
+                0
+            );
             $this->add_conditional_element(
                 'recordingready_enabled',
                 $item,
@@ -1120,15 +1234,19 @@ class settings {
         );
 
         if ($this->admin->fulltree) {
-            $item = new admin_setting_heading('bigbluebuttonbn_config_experimental_features',
+            $item = new admin_setting_heading(
+                'bigbluebuttonbn_config_experimental_features',
                 '',
-                get_string('config_experimental_features_description', 'bigbluebuttonbn'));
+                get_string('config_experimental_features_description', 'bigbluebuttonbn')
+            );
             $experimentalfeaturessetting->add($item);
             // UI for 'register meeting events' feature.
-            $item = new admin_setting_configcheckbox('bigbluebuttonbn_meetingevents_enabled',
+            $item = new admin_setting_configcheckbox(
+                'bigbluebuttonbn_meetingevents_enabled',
                 get_string('config_meetingevents_enabled', 'bigbluebuttonbn'),
                 get_string('config_meetingevents_enabled_description', 'bigbluebuttonbn'),
-                0);
+                0
+            );
             $this->add_conditional_element(
                 'meetingevents_enabled',
                 $item,

--- a/classes/settings.php
+++ b/classes/settings.php
@@ -73,7 +73,7 @@ class settings {
 
         $admin->add('modsettings', $modbigbluebuttobnfolder);
 
-        $mainsettings = $this->bigbluebuttonbn_settings_general($categoryname);
+        $mainsettings = $this->add_general_settings($categoryname);
         $admin->add($categoryname, $mainsettings);
     }
 
@@ -84,25 +84,25 @@ class settings {
         // Evaluates if recordings are enabled for the Moodle site.
 
         // Renders settings for record feature.
-        $this->bigbluebuttonbn_settings_record();
+        $this->add_record_settings();
         // Renders settings for import recordings.
-        $this->bigbluebuttonbn_settings_importrecordings();
+        $this->add_importrecordings_settings();
         // Renders settings for showing recordings.
-        $this->bigbluebuttonbn_settings_showrecordings();
+        $this->add_showrecordings_settings();
 
         // Renders settings for meetings.
-        $this->bigbluebuttonbn_settings_waitmoderator();
-        $this->bigbluebuttonbn_settings_voicebridge();
-        $this->bigbluebuttonbn_settings_preupload();
-        $this->bigbluebuttonbn_settings_userlimit();
-        $this->bigbluebuttonbn_settings_participants();
-        $this->bigbluebuttonbn_settings_notifications();
-        $this->bigbluebuttonbn_settings_muteonstart();
-        $this->bigbluebuttonbn_settings_locksettings();
+        $this->add_waitmoderator_settings();
+        $this->add_voicebridge_settings();
+        $this->add_preupload_settings();
+        $this->add_userlimit_settings();
+        $this->add_participants_settings();
+        $this->add_notifications_settings();
+        $this->add_muteonstart_settings();
+        $this->add_locksettings_settings();
         // Renders settings for extended capabilities.
-        $this->bigbluebuttonbn_settings_extended();
+        $this->add_extended_settings();
         // Renders settings for experimental features.
-        $this->bigbluebuttonbn_settings_experimental();
+        $this->add_experimental_settings();
     }
 
     /**
@@ -131,7 +131,7 @@ class settings {
      * @return admin_settingpage
      * @throws \coding_exception
      */
-    protected function bigbluebuttonbn_settings_general(): admin_settingpage {
+    protected function add_general_settings(): admin_settingpage {
         $settingsgeneral = new admin_settingpage(
             "{$this->sectionnameprefix}_general",
             get_string('config_general', 'bigbluebuttonbn'),
@@ -184,7 +184,7 @@ class settings {
     /**
      * Helper function renders record settings if the feature is enabled.
      */
-    protected function bigbluebuttonbn_settings_record(): void {
+    protected function add_record_settings(): void {
         // Configuration for 'recording' feature.
         $recordingsetting = new admin_settingpage(
             "{$this->sectionnameprefix}_recording",
@@ -270,7 +270,7 @@ class settings {
     /**
      * Helper function renders import recording settings if the feature is enabled.
      */
-    protected function bigbluebuttonbn_settings_importrecordings(): void {
+    protected function add_importrecordings_settings(): void {
         // Configuration for 'import recordings' feature.
         $importrecordingsettings = new admin_settingpage(
             "{$this->sectionnameprefix}_importrecording",
@@ -309,7 +309,7 @@ class settings {
     /**
      * Helper function renders show recording settings if the feature is enabled.
      */
-    protected function bigbluebuttonbn_settings_showrecordings(): void {
+    protected function add_showrecordings_settings(): void {
         // Configuration for 'show recordings' feature.
         $showrecordingsettings = new admin_settingpage(
             "{$this->sectionnameprefix}_showrecordings",
@@ -442,7 +442,7 @@ class settings {
     /**
      * Helper function renders wait for moderator settings if the feature is enabled.
      */
-    protected function bigbluebuttonbn_settings_waitmoderator(): void {
+    protected function add_waitmoderator_settings(): void {
         // Configuration for wait for moderator feature.
         $waitmoderatorsettings = new admin_settingpage(
             "{$this->sectionnameprefix}_waitformoderator",
@@ -499,7 +499,7 @@ class settings {
     /**
      * Helper function renders static voice bridge settings if the feature is enabled.
      */
-    protected function bigbluebuttonbn_settings_voicebridge(): void {
+    protected function add_voicebridge_settings(): void {
         // Configuration for "static voice bridge" feature.
         $voicebridgesettings = new admin_settingpage(
             "{$this->sectionnameprefix}_voicebridge",
@@ -529,7 +529,7 @@ class settings {
     /**
      * Helper function renders preuploaded presentation settings if the feature is enabled.
      */
-    protected function bigbluebuttonbn_settings_preupload(): void {
+    protected function add_preupload_settings(): void {
         // Configuration for "preupload presentation" feature.
         $preuploadsettings = new admin_settingpage(
             "{$this->sectionnameprefix}_preupload",
@@ -579,7 +579,7 @@ class settings {
      * Helper function renders userlimit settings if the feature is enabled.
      */
 
-    protected function bigbluebuttonbn_settings_userlimit(): void {
+    protected function add_userlimit_settings(): void {
         $userlimitsettings = new admin_settingpage(
             "{$this->sectionnameprefix}_userlimit",
             get_string('config_userlimit', 'bigbluebuttonbn'),
@@ -618,7 +618,7 @@ class settings {
     /**
      * Helper function renders participant settings if the feature is enabled.
      */
-    protected function bigbluebuttonbn_settings_participants(): void {
+    protected function add_participants_settings(): void {
         // Configuration for defining the default role/user that will be moderator on new activities.
         $participantsettings = new admin_settingpage(
             "{$this->sectionnameprefix}_participant",
@@ -651,7 +651,7 @@ class settings {
     /**
      * Helper function renders notification settings if the feature is enabled.
      */
-    protected function bigbluebuttonbn_settings_notifications(): void {
+    protected function add_notifications_settings(): void {
         // Configuration for "send notifications" feature.
         $notificationssettings = new admin_settingpage(
             "{$this->sectionnameprefix}_notifications",
@@ -681,7 +681,7 @@ class settings {
     /**
      * Helper function renders general settings if the feature is enabled.
      */
-    protected function bigbluebuttonbn_settings_muteonstart(): void {
+    protected function add_muteonstart_settings(): void {
         // Configuration for BigBlueButton.
         $muteonstartsetting = new admin_settingpage(
             "{$this->sectionnameprefix}_muteonstart",
@@ -720,7 +720,7 @@ class settings {
     /**
      * Helper function renders general settings if the feature is enabled.
      */
-    protected function bigbluebuttonbn_settings_locksettings(): void {
+    protected function add_locksettings_settings(): void {
         $category = new admin_category(
             "{$this->sectionnameprefix}_locksettings",
             get_string('config_locksettings', 'bigbluebuttonbn'),
@@ -730,14 +730,14 @@ class settings {
         $this->admin->add($this->section, $category);
 
         // Configuration for various lock settings for meetings.
-        $this->bigbluebuttonbn_settings_disablecam($category);
-        $this->bigbluebuttonbn_settings_disablemic($category);
-        $this->bigbluebuttonbn_settings_disablepublicchat($category);
-        $this->bigbluebuttonbn_settings_disablenote($category);
-        $this->bigbluebuttonbn_settings_hideuserlist($category);
-        $this->bigbluebuttonbn_settings_lockedlayout($category);
-        $this->bigbluebuttonbn_settings_lockonjoin($category);
-        $this->bigbluebuttonbn_settings_lockonjoinconfigurable($category);
+        $this->add_disablecam_settings($category);
+        $this->add_disablemic_settings($category);
+        $this->add_disablepublicchat_settings($category);
+        $this->add_disablenote_settings($category);
+        $this->add_hideuserlist_settings($category);
+        $this->add_lockedlayout_settings($category);
+        $this->add_lockonjoin_settings($category);
+        $this->add_lockonjoinconfigurable_settings($category);
     }
 
     /**
@@ -745,7 +745,7 @@ class settings {
      *
      * @param admin_category $category The parent category to add to
      */
-    protected function bigbluebuttonbn_settings_disablecam(admin_category $category): void {
+    protected function add_disablecam_settings(admin_category $category): void {
         // Configuration for BigBlueButton.
         $disablecamsettings = new admin_settingpage(
             "{$this->sectionnameprefix}_disablecam",
@@ -782,7 +782,7 @@ class settings {
      *
      * @param admin_category $category The parent category to add to
      */
-    protected function bigbluebuttonbn_settings_disablemic(admin_category $category): void {
+    protected function add_disablemic_settings(admin_category $category): void {
         // Configuration for BigBlueButton.
         $disablemicsetting = new admin_settingpage(
             "{$this->sectionnameprefix}_disablemic",
@@ -817,8 +817,9 @@ class settings {
     /**
      * Helper function renders general settings if the feature is enabled.
      *
+     * @param admin_category $category The parent category to add to
      */
-    protected function bigbluebuttonbn_settings_disableprivatechat(admin_category $category): void {
+    protected function add_disableprivatechat_settings(admin_category $category): void {
         // Configuration for BigBlueButton.
         $disableprivatechatsetting = new admin_settingpage(
             "{$this->sectionnameprefix}_disableprivatechat",
@@ -855,7 +856,7 @@ class settings {
      *
      * @param admin_category $category The parent category to add to
      */
-    protected function bigbluebuttonbn_settings_disablepublicchat(admin_category $category): void {
+    protected function add_disablepublicchat_settings(admin_category $category): void {
         // Configuration for BigBlueButton.
         $disablepublicchatsetting = new admin_settingpage(
             "{$this->sectionnameprefix}_disablepublicchat",
@@ -892,7 +893,7 @@ class settings {
      *
      * @param admin_category $category The parent category to add to
      */
-    protected function bigbluebuttonbn_settings_disablenote(admin_category $category): void {
+    protected function add_disablenote_settings(admin_category $category): void {
         // Configuration for BigBlueButton.
         $disablenotesetting = new admin_settingpage(
             "{$this->sectionnameprefix}_disablenote",
@@ -929,7 +930,7 @@ class settings {
      *
      * @param admin_category $category The parent category to add to
      */
-    protected function bigbluebuttonbn_settings_hideuserlist(admin_category $category): void {
+    protected function add_hideuserlist_settings(admin_category $category): void {
         // Configuration for BigBlueButton.
         $hideuserlistsetting = new admin_settingpage(
             "{$this->sectionnameprefix}_hideuserlist",
@@ -966,7 +967,7 @@ class settings {
      *
      * @param admin_category $category The parent category to add to
      */
-    protected function bigbluebuttonbn_settings_lockedlayout(admin_category $category): void {
+    protected function add_lockedlayout_settings(admin_category $category): void {
         // Configuration for BigBlueButton.
         $lockedlayoutsetting = new admin_settingpage(
             "{$this->sectionnameprefix}_lockedlayout",
@@ -1003,7 +1004,7 @@ class settings {
      *
      * @param admin_category $category The parent category to add to
      */
-    protected function bigbluebuttonbn_settings_lockonjoin(admin_category $category): void {
+    protected function add_lockonjoin_settings(admin_category $category): void {
         // Configuration for BigBlueButton.
         $lockonjoinsetting = new admin_settingpage(
             "{$this->sectionnameprefix}_lockonjoin",
@@ -1042,7 +1043,7 @@ class settings {
      *
      * @param admin_category $category The parent category to add to
      */
-    protected function bigbluebuttonbn_settings_lockonjoinconfigurable(admin_category $category): void {
+    protected function add_lockonjoinconfigurable_settings(admin_category $category): void {
         // Configuration for BigBlueButton.
         $lockonjoinconfigurablesetting = new admin_settingpage(
             "{$this->sectionnameprefix}_lockonjoinconfigurable",
@@ -1077,7 +1078,7 @@ class settings {
     /**
      * Helper function renders extended settings if any of the features there is enabled.
      */
-    protected function bigbluebuttonbn_settings_extended(): void {
+    protected function add_extended_settings(): void {
         // Configuration for extended capabilities.
         $extendedcapabilitiessetting = new admin_settingpage(
             "{$this->sectionnameprefix}_extendedcapabilities",
@@ -1109,7 +1110,7 @@ class settings {
     /**
      * Helper function renders experimental settings if any of the features there is enabled.
      */
-    protected function bigbluebuttonbn_settings_experimental(): void {
+    protected function add_experimental_settings(): void {
         // Configuration for experimental features should go here.
         $experimentalfeaturessetting = new admin_settingpage(
             "{$this->sectionnameprefix}_experimentalfeatures",

--- a/classes/settings.php
+++ b/classes/settings.php
@@ -22,7 +22,7 @@
  * @author    Laurent David  (laurent [at] call-learning [dt] fr)
  */
 
-namespace mod_bigbluebuttonbn\local\settings;
+namespace mod_bigbluebuttonbn;
 
 use admin_category;
 use admin_setting;
@@ -78,6 +78,34 @@ class settings {
     }
 
     /**
+     * Add all settings.
+     */
+    public function add_all_settings(): void {
+        // Evaluates if recordings are enabled for the Moodle site.
+
+        // Renders settings for record feature.
+        $this->bigbluebuttonbn_settings_record();
+        // Renders settings for import recordings.
+        $this->bigbluebuttonbn_settings_importrecordings();
+        // Renders settings for showing recordings.
+        $this->bigbluebuttonbn_settings_showrecordings();
+
+        // Renders settings for meetings.
+        $this->bigbluebuttonbn_settings_waitmoderator();
+        $this->bigbluebuttonbn_settings_voicebridge();
+        $this->bigbluebuttonbn_settings_preupload();
+        $this->bigbluebuttonbn_settings_userlimit();
+        $this->bigbluebuttonbn_settings_participants();
+        $this->bigbluebuttonbn_settings_notifications();
+        $this->bigbluebuttonbn_settings_muteonstart();
+        $this->bigbluebuttonbn_settings_locksettings();
+        // Renders settings for extended capabilities.
+        $this->bigbluebuttonbn_settings_extended();
+        // Renders settings for experimental features.
+        $this->bigbluebuttonbn_settings_experimental();
+    }
+
+    /**
      * Add the setting and lock it conditionally.
      *
      * @param string $name
@@ -103,12 +131,12 @@ class settings {
      * @return admin_settingpage
      * @throws \coding_exception
      */
-    public function bigbluebuttonbn_settings_general(): admin_settingpage {
+    protected function bigbluebuttonbn_settings_general(): admin_settingpage {
         $settingsgeneral = new admin_settingpage(
             "{$this->sectionnameprefix}_general",
             get_string('config_general', 'bigbluebuttonbn'),
             'moodle/site:config',
-            !((boolean) validator::section_general_shown()) && ($this->moduleenabled)
+            !((boolean) setting_validator::section_general_shown()) && ($this->moduleenabled)
         );
         if ($this->admin->fulltree) {
             // Configuration for BigBlueButton.
@@ -156,13 +184,13 @@ class settings {
     /**
      * Helper function renders record settings if the feature is enabled.
      */
-    public function bigbluebuttonbn_settings_record(): void {
+    protected function bigbluebuttonbn_settings_record(): void {
         // Configuration for 'recording' feature.
         $recordingsetting = new admin_settingpage(
             "{$this->sectionnameprefix}_recording",
             get_string('config_recording', 'bigbluebuttonbn'),
             'moodle/site:config',
-            !((boolean) validator::section_record_meeting_shown()) && ($this->moduleenabled)
+            !((boolean) setting_validator::section_record_meeting_shown()) && ($this->moduleenabled)
         );
 
         if ($this->admin->fulltree) {
@@ -242,13 +270,13 @@ class settings {
     /**
      * Helper function renders import recording settings if the feature is enabled.
      */
-    public function bigbluebuttonbn_settings_importrecordings(): void {
+    protected function bigbluebuttonbn_settings_importrecordings(): void {
         // Configuration for 'import recordings' feature.
         $importrecordingsettings = new admin_settingpage(
             "{$this->sectionnameprefix}_importrecording",
             get_string('config_importrecordings', 'bigbluebuttonbn'),
             'moodle/site:config',
-            !((boolean) validator::section_import_recordings_shown()) && ($this->moduleenabled)
+            !((boolean) setting_validator::section_import_recordings_shown()) && ($this->moduleenabled)
         );
 
         if ($this->admin->fulltree) {
@@ -281,105 +309,127 @@ class settings {
     /**
      * Helper function renders show recording settings if the feature is enabled.
      */
-    public function bigbluebuttonbn_settings_showrecordings(): void {
+    protected function bigbluebuttonbn_settings_showrecordings(): void {
         // Configuration for 'show recordings' feature.
         $showrecordingsettings = new admin_settingpage(
             "{$this->sectionnameprefix}_showrecordings",
             get_string('config_recordings', 'bigbluebuttonbn'),
             'moodle/site:config',
-            !((boolean) validator::section_show_recordings_shown()) && ($this->moduleenabled)
+            !((boolean) setting_validator::section_show_recordings_shown()) && ($this->moduleenabled)
         );
 
         if ($this->admin->fulltree) {
-            $item = new admin_setting_heading('bigbluebuttonbn_config_recordings',
+            $item = new admin_setting_heading(
+                'bigbluebuttonbn_config_recordings',
                 '',
-                get_string('config_recordings_description', 'bigbluebuttonbn'));
+                get_string('config_recordings_description', 'bigbluebuttonbn')
+            );
             $showrecordingsettings->add($item);
-            $item = new admin_setting_configcheckbox('bigbluebuttonbn_recordings_html_default',
+            $item = new admin_setting_configcheckbox(
+                'bigbluebuttonbn_recordings_html_default',
                 get_string('config_recordings_html_default', 'bigbluebuttonbn'),
                 get_string('config_recordings_html_default_description', 'bigbluebuttonbn'),
-                1);
+                1
+            );
             $this->add_conditional_element(
                 'recordings_html_default',
                 $item,
                 $showrecordingsettings
             );
-            $item = new admin_setting_configcheckbox('bigbluebuttonbn_recordings_html_editable',
+            $item = new admin_setting_configcheckbox(
+                'bigbluebuttonbn_recordings_html_editable',
                 get_string('config_recordings_html_editable', 'bigbluebuttonbn'),
                 get_string('config_recordings_html_editable_description', 'bigbluebuttonbn'),
-                0);
+                0
+            );
             $this->add_conditional_element(
                 'recordings_html_editable',
                 $item,
                 $showrecordingsettings
             );
-            $item = new admin_setting_configcheckbox('bigbluebuttonbn_recordings_deleted_default',
+            $item = new admin_setting_configcheckbox(
+                'bigbluebuttonbn_recordings_deleted_default',
                 get_string('config_recordings_deleted_default', 'bigbluebuttonbn'),
                 get_string('config_recordings_deleted_default_description', 'bigbluebuttonbn'),
-                1);
+                1
+            );
             $this->add_conditional_element(
                 'recordings_deleted_default',
                 $item,
                 $showrecordingsettings
             );
-            $item = new admin_setting_configcheckbox('bigbluebuttonbn_recordings_deleted_editable',
+            $item = new admin_setting_configcheckbox(
+                'bigbluebuttonbn_recordings_deleted_editable',
                 get_string('config_recordings_deleted_editable', 'bigbluebuttonbn'),
                 get_string('config_recordings_deleted_editable_description', 'bigbluebuttonbn'),
-                0);
+                0
+            );
             $this->add_conditional_element(
                 'recordings_deleted_editable',
                 $item,
                 $showrecordingsettings
             );
-            $item = new admin_setting_configcheckbox('bigbluebuttonbn_recordings_imported_default',
+            $item = new admin_setting_configcheckbox(
+                'bigbluebuttonbn_recordings_imported_default',
                 get_string('config_recordings_imported_default', 'bigbluebuttonbn'),
                 get_string('config_recordings_imported_default_description', 'bigbluebuttonbn'),
-                0);
+                0
+            );
             $this->add_conditional_element(
                 'recordings_imported_default',
                 $item,
                 $showrecordingsettings
             );
-            $item = new admin_setting_configcheckbox('bigbluebuttonbn_recordings_imported_editable',
+            $item = new admin_setting_configcheckbox(
+                'bigbluebuttonbn_recordings_imported_editable',
                 get_string('config_recordings_imported_editable', 'bigbluebuttonbn'),
                 get_string('config_recordings_imported_editable_description', 'bigbluebuttonbn'),
-                1);
+                1
+            );
             $this->add_conditional_element(
                 'recordings_imported_editable',
                 $item,
                 $showrecordingsettings
             );
-            $item = new admin_setting_configcheckbox('bigbluebuttonbn_recordings_preview_default',
+            $item = new admin_setting_configcheckbox(
+                'bigbluebuttonbn_recordings_preview_default',
                 get_string('config_recordings_preview_default', 'bigbluebuttonbn'),
                 get_string('config_recordings_preview_default_description', 'bigbluebuttonbn'),
-                1);
+                1
+            );
             $this->add_conditional_element(
                 'recordings_preview_default',
                 $item,
                 $showrecordingsettings
             );
-            $item = new admin_setting_configcheckbox('bigbluebuttonbn_recordings_preview_editable',
+            $item = new admin_setting_configcheckbox(
+                'bigbluebuttonbn_recordings_preview_editable',
                 get_string('config_recordings_preview_editable', 'bigbluebuttonbn'),
                 get_string('config_recordings_preview_editable_description', 'bigbluebuttonbn'),
-                0);
+                0
+            );
             $this->add_conditional_element(
                 'recordings_preview_editable',
                 $item,
                 $showrecordingsettings
             );
-            $item = new admin_setting_configcheckbox('bigbluebuttonbn_recordings_sortorder',
+            $item = new admin_setting_configcheckbox(
+                'bigbluebuttonbn_recordings_sortorder',
                 get_string('config_recordings_sortorder', 'bigbluebuttonbn'),
                 get_string('config_recordings_sortorder_description', 'bigbluebuttonbn'),
-                0);
+                0
+            );
             $this->add_conditional_element(
                 'recordings_sortorder',
                 $item,
                 $showrecordingsettings
             );
-            $item = new admin_setting_configcheckbox('bigbluebuttonbn_recordings_validate_url',
+            $item = new admin_setting_configcheckbox(
+                'bigbluebuttonbn_recordings_validate_url',
                 get_string('config_recordings_validate_url', 'bigbluebuttonbn'),
                 get_string('config_recordings_validate_url_description', 'bigbluebuttonbn'),
-                1);
+                1
+            );
             $this->add_conditional_element(
                 'recordings_validate_url',
                 $item,
@@ -392,13 +442,13 @@ class settings {
     /**
      * Helper function renders wait for moderator settings if the feature is enabled.
      */
-    public function bigbluebuttonbn_settings_waitmoderator(): void {
+    protected function bigbluebuttonbn_settings_waitmoderator(): void {
         // Configuration for wait for moderator feature.
         $waitmoderatorsettings = new admin_settingpage(
             "{$this->sectionnameprefix}_waitformoderator",
             get_string('config_waitformoderator', 'bigbluebuttonbn'),
             'moodle/site:config',
-            !((boolean) validator::section_wait_moderator_shown()) && ($this->moduleenabled)
+            !((boolean) setting_validator::section_wait_moderator_shown()) && ($this->moduleenabled)
         );
 
         if ($this->admin->fulltree) {
@@ -449,13 +499,13 @@ class settings {
     /**
      * Helper function renders static voice bridge settings if the feature is enabled.
      */
-    public function bigbluebuttonbn_settings_voicebridge(): void {
+    protected function bigbluebuttonbn_settings_voicebridge(): void {
         // Configuration for "static voice bridge" feature.
         $voicebridgesettings = new admin_settingpage(
             "{$this->sectionnameprefix}_voicebridge",
             get_string('config_voicebridge', 'bigbluebuttonbn'),
             'moodle/site:config',
-            !((boolean) validator::section_static_voice_bridge_shown()) && ($this->moduleenabled)
+            !((boolean) setting_validator::section_static_voice_bridge_shown()) && ($this->moduleenabled)
         );
 
         if ($this->admin->fulltree) {
@@ -479,13 +529,13 @@ class settings {
     /**
      * Helper function renders preuploaded presentation settings if the feature is enabled.
      */
-    public function bigbluebuttonbn_settings_preupload(): void {
+    protected function bigbluebuttonbn_settings_preupload(): void {
         // Configuration for "preupload presentation" feature.
         $preuploadsettings = new admin_settingpage(
             "{$this->sectionnameprefix}_preupload",
             get_string('config_preuploadpresentation', 'bigbluebuttonbn'),
             'moodle/site:config',
-            !((boolean) validator::section_preupload_presentation_shown()) && ($this->moduleenabled)
+            !((boolean) setting_validator::section_preupload_presentation_shown()) && ($this->moduleenabled)
         );
 
         if ($this->admin->fulltree) {
@@ -529,12 +579,12 @@ class settings {
      * Helper function renders userlimit settings if the feature is enabled.
      */
 
-    public function bigbluebuttonbn_settings_userlimit(): void {
+    protected function bigbluebuttonbn_settings_userlimit(): void {
         $userlimitsettings = new admin_settingpage(
             "{$this->sectionnameprefix}_userlimit",
             get_string('config_userlimit', 'bigbluebuttonbn'),
             'moodle/site:config',
-            !((boolean) validator::section_user_limit_shown()) && ($this->moduleenabled)
+            !((boolean) setting_validator::section_user_limit_shown()) && ($this->moduleenabled)
         );
 
         if ($this->admin->fulltree) {
@@ -568,13 +618,13 @@ class settings {
     /**
      * Helper function renders participant settings if the feature is enabled.
      */
-    public function bigbluebuttonbn_settings_participants(): void {
+    protected function bigbluebuttonbn_settings_participants(): void {
         // Configuration for defining the default role/user that will be moderator on new activities.
         $participantsettings = new admin_settingpage(
             "{$this->sectionnameprefix}_participant",
             get_string('config_participant', 'bigbluebuttonbn'),
             'moodle/site:config',
-            !((boolean) validator::section_moderator_default_shown()) && ($this->moduleenabled)
+            !((boolean) setting_validator::section_moderator_default_shown()) && ($this->moduleenabled)
         );
 
         if ($this->admin->fulltree) {
@@ -601,13 +651,13 @@ class settings {
     /**
      * Helper function renders notification settings if the feature is enabled.
      */
-    public function bigbluebuttonbn_settings_notifications(): void {
+    protected function bigbluebuttonbn_settings_notifications(): void {
         // Configuration for "send notifications" feature.
         $notificationssettings = new admin_settingpage(
             "{$this->sectionnameprefix}_notifications",
             get_string('config_sendnotifications', 'bigbluebuttonbn'),
             'moodle/site:config',
-            !((boolean) validator::section_send_notifications_shown()) && ($this->moduleenabled)
+            !((boolean) setting_validator::section_send_notifications_shown()) && ($this->moduleenabled)
         );
 
         if ($this->admin->fulltree) {
@@ -631,13 +681,13 @@ class settings {
     /**
      * Helper function renders general settings if the feature is enabled.
      */
-    public function bigbluebuttonbn_settings_muteonstart(): void {
+    protected function bigbluebuttonbn_settings_muteonstart(): void {
         // Configuration for BigBlueButton.
         $muteonstartsetting = new admin_settingpage(
             "{$this->sectionnameprefix}_muteonstart",
             get_string('config_muteonstart', 'bigbluebuttonbn'),
             'moodle/site:config',
-            !((boolean) validator::section_muteonstart_shown()) && ($this->moduleenabled)
+            !((boolean) setting_validator::section_muteonstart_shown()) && ($this->moduleenabled)
         );
 
         if ($this->admin->fulltree) {
@@ -670,7 +720,7 @@ class settings {
     /**
      * Helper function renders general settings if the feature is enabled.
      */
-    public function bigbluebuttonbn_settings_locksettings(): void {
+    protected function bigbluebuttonbn_settings_locksettings(): void {
         $category = new admin_category(
             "{$this->sectionnameprefix}_locksettings",
             get_string('config_locksettings', 'bigbluebuttonbn'),
@@ -695,13 +745,13 @@ class settings {
      *
      * @param admin_category $category The parent category to add to
      */
-    public function bigbluebuttonbn_settings_disablecam(admin_category $category): void {
+    protected function bigbluebuttonbn_settings_disablecam(admin_category $category): void {
         // Configuration for BigBlueButton.
         $disablecamsettings = new admin_settingpage(
             "{$this->sectionnameprefix}_disablecam",
             get_string('config_disablecam_default', 'bigbluebuttonbn'),
             'moodle/site:config',
-            !((boolean) validator::section_disablecam_shown()) && ($this->moduleenabled)
+            !((boolean) setting_validator::section_disablecam_shown()) && ($this->moduleenabled)
         );
 
         if ($this->admin->fulltree) {
@@ -732,13 +782,13 @@ class settings {
      *
      * @param admin_category $category The parent category to add to
      */
-    public function bigbluebuttonbn_settings_disablemic(admin_category $category): void {
+    protected function bigbluebuttonbn_settings_disablemic(admin_category $category): void {
         // Configuration for BigBlueButton.
         $disablemicsetting = new admin_settingpage(
             "{$this->sectionnameprefix}_disablemic",
             get_string('config_disablemic_default', 'bigbluebuttonbn'),
             'moodle/site:config',
-            !((boolean) validator::section_disablemic_shown()) && ($this->moduleenabled)
+            !((boolean) setting_validator::section_disablemic_shown()) && ($this->moduleenabled)
         );
 
         if ($this->admin->fulltree) {
@@ -768,13 +818,13 @@ class settings {
      * Helper function renders general settings if the feature is enabled.
      *
      */
-    public function bigbluebuttonbn_settings_disableprivatechat(admin_category $category): void {
+    protected function bigbluebuttonbn_settings_disableprivatechat(admin_category $category): void {
         // Configuration for BigBlueButton.
         $disableprivatechatsetting = new admin_settingpage(
             "{$this->sectionnameprefix}_disableprivatechat",
             get_string('config_disableprivatechat_default', 'bigbluebuttonbn'),
             'moodle/site:config',
-            !((boolean) validator::section_disableprivatechat_shown()) && ($this->moduleenabled)
+            !((boolean) setting_validator::section_disableprivatechat_shown()) && ($this->moduleenabled)
         );
 
         if ($this->admin->fulltree) {
@@ -805,13 +855,13 @@ class settings {
      *
      * @param admin_category $category The parent category to add to
      */
-    public function bigbluebuttonbn_settings_disablepublicchat(admin_category $category): void {
+    protected function bigbluebuttonbn_settings_disablepublicchat(admin_category $category): void {
         // Configuration for BigBlueButton.
         $disablepublicchatsetting = new admin_settingpage(
             "{$this->sectionnameprefix}_disablepublicchat",
             get_string('config_disableprivatechat_default', 'bigbluebuttonbn'),
             'moodle/site:config',
-            !((boolean) validator::section_disablepublicchat_shown()) && ($this->moduleenabled)
+            !((boolean) setting_validator::section_disablepublicchat_shown()) && ($this->moduleenabled)
         );
 
         if ($this->admin->fulltree) {
@@ -842,13 +892,13 @@ class settings {
      *
      * @param admin_category $category The parent category to add to
      */
-    public function bigbluebuttonbn_settings_disablenote(admin_category $category): void {
+    protected function bigbluebuttonbn_settings_disablenote(admin_category $category): void {
         // Configuration for BigBlueButton.
         $disablenotesetting = new admin_settingpage(
             "{$this->sectionnameprefix}_disablenote",
             get_string('config_disablenote_default', 'bigbluebuttonbn'),
             'moodle/site:config',
-            !((boolean) validator::section_disablenote_shown()) && ($this->moduleenabled)
+            !((boolean) setting_validator::section_disablenote_shown()) && ($this->moduleenabled)
         );
 
         if ($this->admin->fulltree) {
@@ -879,13 +929,13 @@ class settings {
      *
      * @param admin_category $category The parent category to add to
      */
-    public function bigbluebuttonbn_settings_hideuserlist(admin_category $category): void {
+    protected function bigbluebuttonbn_settings_hideuserlist(admin_category $category): void {
         // Configuration for BigBlueButton.
         $hideuserlistsetting = new admin_settingpage(
             "{$this->sectionnameprefix}_hideuserlist",
             get_string('config_hideuserlist_default', 'bigbluebuttonbn'),
             'moodle/site:config',
-            !((boolean) validator::section_hideuserlist_shown()) && ($this->moduleenabled)
+            !((boolean) setting_validator::section_hideuserlist_shown()) && ($this->moduleenabled)
         );
 
         if ($this->admin->fulltree) {
@@ -916,13 +966,13 @@ class settings {
      *
      * @param admin_category $category The parent category to add to
      */
-    public function bigbluebuttonbn_settings_lockedlayout(admin_category $category): void {
+    protected function bigbluebuttonbn_settings_lockedlayout(admin_category $category): void {
         // Configuration for BigBlueButton.
         $lockedlayoutsetting = new admin_settingpage(
             "{$this->sectionnameprefix}_lockedlayout",
             get_string('config_lockedlayout_default', 'bigbluebuttonbn'),
             'moodle/site:config',
-            !((boolean) validator::section_lockedlayout_shown()) && ($this->moduleenabled)
+            !((boolean) setting_validator::section_lockedlayout_shown()) && ($this->moduleenabled)
         );
 
         if ($this->admin->fulltree) {
@@ -953,17 +1003,17 @@ class settings {
      *
      * @param admin_category $category The parent category to add to
      */
-    public function bigbluebuttonbn_settings_lockonjoin(admin_category $category): void {
+    protected function bigbluebuttonbn_settings_lockonjoin(admin_category $category): void {
         // Configuration for BigBlueButton.
         $lockonjoinsetting = new admin_settingpage(
             "{$this->sectionnameprefix}_lockonjoin",
             get_string('config_lockonjoin_default', 'bigbluebuttonbn'),
             'moodle/site:config',
-            !((boolean) validator::section_lockonjoin_shown()) && ($this->moduleenabled)
+            !((boolean) setting_validator::section_lockonjoin_shown()) && ($this->moduleenabled)
         );
 
         if ($this->admin->fulltree) {
-            if ((boolean) validator::section_lockonjoin_shown()) {
+            if ((boolean) setting_validator::section_lockonjoin_shown()) {
                 $item = new admin_setting_configcheckbox('bigbluebuttonbn_lockonjoin_default',
                     get_string('config_lockonjoin_default', 'bigbluebuttonbn'),
                     get_string('config_lockonjoin_default_description', 'bigbluebuttonbn'),
@@ -992,13 +1042,13 @@ class settings {
      *
      * @param admin_category $category The parent category to add to
      */
-    public function bigbluebuttonbn_settings_lockonjoinconfigurable(admin_category $category): void {
+    protected function bigbluebuttonbn_settings_lockonjoinconfigurable(admin_category $category): void {
         // Configuration for BigBlueButton.
         $lockonjoinconfigurablesetting = new admin_settingpage(
             "{$this->sectionnameprefix}_lockonjoinconfigurable",
             get_string('config_lockonjoinconfigurable_default', 'bigbluebuttonbn'),
             'moodle/site:config',
-            !((boolean) validator::section_lockonjoinconfigurable_shown()) && ($this->moduleenabled)
+            !((boolean) setting_validator::section_lockonjoinconfigurable_shown()) && ($this->moduleenabled)
         );
 
         if ($this->admin->fulltree) {
@@ -1027,13 +1077,13 @@ class settings {
     /**
      * Helper function renders extended settings if any of the features there is enabled.
      */
-    public function bigbluebuttonbn_settings_extended(): void {
+    protected function bigbluebuttonbn_settings_extended(): void {
         // Configuration for extended capabilities.
         $extendedcapabilitiessetting = new admin_settingpage(
             "{$this->sectionnameprefix}_extendedcapabilities",
             get_string('config_extended_capabilities', 'bigbluebuttonbn'),
             'moodle/site:config',
-            !((boolean) validator::section_settings_extended_shown()) && ($this->moduleenabled)
+            !((boolean) setting_validator::section_settings_extended_shown()) && ($this->moduleenabled)
         );
 
         if ($this->admin->fulltree) {
@@ -1059,13 +1109,13 @@ class settings {
     /**
      * Helper function renders experimental settings if any of the features there is enabled.
      */
-    public function bigbluebuttonbn_settings_experimental(): void {
+    protected function bigbluebuttonbn_settings_experimental(): void {
         // Configuration for experimental features should go here.
         $experimentalfeaturessetting = new admin_settingpage(
             "{$this->sectionnameprefix}_experimentalfeatures",
             get_string('config_experimental_features', 'bigbluebuttonbn'),
             'moodle/site:config',
-            !((boolean) validator::section_settings_extended_shown()) && ($this->moduleenabled)
+            !((boolean) setting_validator::section_settings_extended_shown()) && ($this->moduleenabled)
         );
 
         if ($this->admin->fulltree) {

--- a/settings.php
+++ b/settings.php
@@ -24,38 +24,7 @@
  * @author    Fred Dixon  (ffdixon [at] blindsidenetworks [dt] com)
  */
 
-use mod_bigbluebuttonbn\local\settings\renderer;
-use mod_bigbluebuttonbn\local\settings\settings;
-use mod_bigbluebuttonbn\local\settings\validator;
-
-defined('MOODLE_INTERNAL') || die;
-
-global $CFG;
-
-$bbbsettings = new settings($ADMIN, $module, $section);
-
-// Evaluates if recordings are enabled for the Moodle site.
-
-// Renders settings for record feature.
-$bbbsettings->bigbluebuttonbn_settings_record();
-// Renders settings for import recordings.
-$bbbsettings->bigbluebuttonbn_settings_importrecordings();
-// Renders settings for showing recordings.
-$bbbsettings->bigbluebuttonbn_settings_showrecordings();
-
-// Renders settings for meetings.
-$bbbsettings->bigbluebuttonbn_settings_waitmoderator();
-$bbbsettings->bigbluebuttonbn_settings_voicebridge();
-$bbbsettings->bigbluebuttonbn_settings_preupload();
-$bbbsettings->bigbluebuttonbn_settings_userlimit();
-$bbbsettings->bigbluebuttonbn_settings_participants();
-$bbbsettings->bigbluebuttonbn_settings_notifications();
-$bbbsettings->bigbluebuttonbn_settings_muteonstart();
-$bbbsettings->bigbluebuttonbn_settings_locksettings();
-// Renders settings for extended capabilities.
-$bbbsettings->bigbluebuttonbn_settings_extended();
-// Renders settings for experimental features.
-$bbbsettings->bigbluebuttonbn_settings_experimental();
+$bbbsettings = new mod_bigbluebuttonbn\settings($ADMIN, $module, $section);
+$bbbsettings->add_all_settings();
 
 $settings = null;
-


### PR DESCRIPTION
Restructure the settings page to:
- meet coding style guidelines for Moodle core
- make the default page the admin category

Note: The "Settings" link in the "Plugins overview" page will be missing
until MDL-72163 is applied.