### PR TITLE
A variety of fixes for PHPUnit, Behat, and GHA as part of CONTRIB-8660

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,7 +44,7 @@ jobs:
           - 3306:3306
         options: --health-cmd="mysqladmin ping" --health-interval 10s --health-timeout 5s --health-retries 3
       mockserver:
-        image: calllearning/bigbluebutton_mock:latest
+        image: andrewnicols/bigbluebutton_mock:latest
         ports:
           - 8001:80
 
@@ -81,8 +81,10 @@ jobs:
           MOODLE_BRANCH: ${{ matrix.moodle-branch }}
           MOODLE_BEHAT_WWWROOT: "http://172.17.0.1:8000"
 
+      # We use a hash of the behat_wwwroot to give a per-parallel run identifier for the mock server.
+      # The moodle-plugin-ci config always sets a behat_wwwroot so there is no need to put this in an empty tests.
       - name: Set additional config
-        run: moodle-plugin-ci add-config 'define("TEST_MOD_BIGBLUEBUTTONBN_MOCK_SERVER", "http://localhost:8001");'
+        run: moodle-plugin-ci add-config 'define("TEST_MOD_BIGBLUEBUTTONBN_MOCK_SERVER", "http://localhost:8001/hash" . sha1($CFG->behat_wwwroot));'
 
       - name: phplint
         if: ${{ always() }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -79,7 +79,7 @@ jobs:
         env:
           DB: ${{ matrix.database }}
           MOODLE_BRANCH: ${{ matrix.moodle-branch }}
-          BEHATWWWROOT: "http://172.17.0.1"
+          MOODLE_BEHAT_WWWROOT: "http://172.17.0.1:8000"
 
       - name: Set additional config
         run: moodle-plugin-ci add-config 'define("TEST_MOD_BIGBLUEBUTTONBN_MOCK_SERVER", "http://localhost:8001");'
@@ -119,6 +119,11 @@ jobs:
       - name: phpunit
         if: ${{ always() }}
         run: moodle-plugin-ci phpunit
+
+      - name: Behat server for docker
+        if: ${{ always() }}
+        run: |
+          php -S 172.17.0.1:8000 -t moodle &
 
       - name: behat
         if: ${{ always() }}

--- a/classes/test/testcase_helper.php
+++ b/classes/test/testcase_helper.php
@@ -140,4 +140,12 @@ class testcase_helper extends advanced_testcase {
         get_fast_modinfo(0, 0, true);
         return array($course, $groups, $students, $teachers, $bbactivity, $roleids);
     }
+
+    protected function require_mock_server(): void {
+        if (!defined('TEST_MOD_BIGBLUEBUTTONBN_MOCK_SERVER')) {
+            $this->markTestSkipped(
+                'The TEST_MOD_BIGBLUEBUTTONBN_MOCK_SERVER constant must be defined to run mod_bigbluebuttonbn tests'
+            );
+        }
+    }
 }

--- a/tests/behat/behat_mod_bigbluebuttonbn.php
+++ b/tests/behat/behat_mod_bigbluebuttonbn.php
@@ -78,30 +78,6 @@ class behat_mod_bigbluebuttonbn extends behat_base {
     }
 
     /**
-     * Return the list of partial named selectors.
-     *
-     * @return array
-     */
-    public static function get_partial_named_selectors(): array {
-        return [
-            new behat_component_named_selector('Meeting identifier', [".//*[@data-identifier=%locator%]"]),
-        ];
-    }
-
-    /**
-     * Return the list of exact named selectors.
-     *
-     * @return array
-     */
-    public static function get_exact_named_selectors(): array {
-        return [
-            new behat_component_named_selector('Recording row',
-                ["//*[@class='mod_bigbluebuttonbn_recordings_table']//tbody[@class='yui3-datatable-data']/tr[position()=%locator%]"]
-            )
-        ];
-    }
-
-    /**
      * Convert page names to URLs for steps like 'When I am on the "[page name]" page'.
      *
      * Recognised page names are:

--- a/tests/behat/recordings.feature
+++ b/tests/behat/recordings.feature
@@ -46,8 +46,8 @@ Feature: The recording can be managed through the room page
   Scenario: I can see the recordings related to an activity
     Given the BigBlueButtonBN server has sent recording ready notifications
     When I am on the "RoomRecordings" "bigbluebuttonbn activity" page logged in as admin
-    Then I should see "Recording 1" in the "1" "mod_bigbluebuttonbn > Recording row"
-    And I should see "Recording 2" in the "2" "mod_bigbluebuttonbn > Recording row"
+    Then "Recording 1" "table_row" should exist
+    And "Recording 2" "table_row" should exist
 
   @javascript
   Scenario: I can rename the recording

--- a/tests/behat/recordings_import.feature
+++ b/tests/behat/recordings_import.feature
@@ -38,12 +38,12 @@ Feature: Manage and list recordings
     And I select "Test Course 1 (C1)" from the "courseidscope" singleselect
     And I select "RoomRecordings" from the "frombn" singleselect
     # add the first recording
-    And I click on "a.action-icon" "css_element" in the "1" "mod_bigbluebuttonbn > Recording row"
+    And I click on "a.action-icon" "css_element" in the "Recording 1" "table_row"
     # add the second recording
-    And I click on "a.action-icon" "css_element" in the "1" "mod_bigbluebuttonbn > Recording row"
+    And I click on "a.action-icon" "css_element" in the "Recording 2" "table_row"
     And I click on "Go back" "button"
-    Then I should see "Recording 1" in the "1" "mod_bigbluebuttonbn > Recording row"
-    And I should see "Recording 2" in the "2" "mod_bigbluebuttonbn > Recording row"
+    Then "Recording 1" "table_row" should exist
+    And "Recording 2" "table_row" should exist
 
   @javascript
   Scenario: I check that I can import recordings into the Recording Only activity and then if I delete them
@@ -53,15 +53,15 @@ Feature: Manage and list recordings
     And I select "Test Course 1 (C1)" from the "courseidscope" singleselect
     And I select "RoomRecordings" from the "frombn" singleselect
     # add the first recording
-    And I click on "a.action-icon" "css_element" in the "1" "mod_bigbluebuttonbn > Recording row"
+    And I click on "a.action-icon" "css_element" in the "Recording 1" "table_row"
     # add the second recording
-    And I click on "a.action-icon" "css_element" in the "1" "mod_bigbluebuttonbn > Recording row"
+    And I click on "a.action-icon" "css_element" in the "Recording 2" "table_row"
     And I wait until the page is ready
     And I click on "Go back" "button"
     # This should be refactored with the right classes for the table element
     # We use javascript here to create the table so we don't get the same structure.
-    And I should see "Recording 1" in the "1" "mod_bigbluebuttonbn > Recording row"
-    And I click on "a[data-action='delete']" "css_element" in the "1" "mod_bigbluebuttonbn > Recording row"
+    Then "Recording 1" "table_row" should exist
+    And I click on "a[data-action='delete']" "css_element" in the "Recording 1" "table_row"
     And I click on "OK" "button" in the "Confirm" "dialogue"
     # There is no confirmation dialog when deleting an imported record.
     And I wait until the page is ready

--- a/tests/completion_test.php
+++ b/tests/completion_test.php
@@ -30,8 +30,10 @@ use mod_bigbluebuttonbn\test\testcase_helper;
  * @copyright 2021 - present, Blindside Networks Inc
  * @license   http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  * @author    Laurent David (laurent@call-learning.fr)
+ * @covers mod_bigbluebuttonbn\completion\custom_completion
  */
 class completion_test extends testcase_helper {
+
     public function test_bigbluebuttonbn_get_completion_state_no_rules() {
         $this->resetAfterTest();
         list($bbactivitycontext, $bbactivitycm, $bbactivity) = $this->create_instance();

--- a/tests/coverage.php
+++ b/tests/coverage.php
@@ -37,11 +37,13 @@ defined('MOODLE_INTERNAL') || die();
 class bbb_coverage extends phpunit_coverage_info {
     /** @var array The list of folders relative to the plugin root to whitelist in coverage generation. */
     protected $whitelistfolders = [
-            'classes',
+        'classes',
     ];
 
     /** @var array The list of files relative to the plugin root to whitelist in coverage generation. */
-    protected $whitelistfiles = ['lib.php'];
+    protected $whitelistfiles = [
+        'lib.php',
+    ];
 
     /** @var array The list of folders relative to the plugin root to excludelist in coverage generation. */
     protected $excludelistfolders = [];

--- a/tests/instance_test.php
+++ b/tests/instance_test.php
@@ -32,6 +32,7 @@ use moodle_exception;
  * @package   mod_bigbluebuttonbn
  * @copyright 2021 Andrew Lyons <andrew@nicols.co.uk>
  * @license   http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ * @coversDefaultClass \mod_bigbluebuttonbn\instance
  */
 class instance_test extends advanced_testcase {
 
@@ -41,6 +42,8 @@ class instance_test extends advanced_testcase {
      * @param string $function
      * @param string $field
      * @dataProvider get_from_location_provider
+     * @covers ::get_from_instanceid
+     * @covers ::get_from_cmid
      */
     public function test_get_from(string $function, string $field): void {
         $this->resetAfterTest();
@@ -71,6 +74,7 @@ class instance_test extends advanced_testcase {
 
     /**
      * Get an instance from a cmid.
+     * @covers ::get_from_cmid
      */
     public function test_get_from_cmid(): void {
         $this->resetAfterTest();
@@ -89,6 +93,7 @@ class instance_test extends advanced_testcase {
 
     /**
      * If the instance was not found, and exception should be thrown.
+     * @covers ::get_from_cmid
      */
     public function test_get_from_cmid_not_found(): void {
         $this->assertNull(instance::get_from_cmid(100));
@@ -97,12 +102,14 @@ class instance_test extends advanced_testcase {
     /**
      * If the instance was not found, and exception should be thrown.
      */
-    public function test_get_from_instnace_not_found(): void {
+    public function test_get_from_instance_not_found(): void {
         $this->assertNull(instance::get_from_instanceid(100));
     }
 
     /**
      * Get from meeting id
+     *
+     * @covers ::get_from_meetingid
      */
     public function test_get_from_meetingid(): void {
         $this->resetAfterTest();
@@ -126,10 +133,35 @@ class instance_test extends advanced_testcase {
     }
 
     /**
+     * Get the get_from_meetingid() function where the meetingid includes a groupid.
+     *
+     * @covers ::get_from_meetingid
+     */
+    public function test_get_from_meetingid_group(): void {
+        $this->resetAfterTest();
+
+        [
+            'record' => $record,
+            'course' => $course,
+            'cm' => $cm,
+        ] = $this->get_test_instance();
+
+        $group = $this->getDataGenerator()->create_group(['courseid' => $course->id]);
+
+        $instance = instance::get_from_meetingid(
+            sprintf("%s-%s-%s[0]", $record->meetingid, $record->course, $record->id)
+        );
+
+        $this->assertEquals($cm->instance, $instance->get_instance_id());
+        $this->assertEquals($cm->id, $instance->get_cm_id());
+    }
+
+    /**
      * Ensure that invalid meetingids throw an appropriate exception.
      *
      * @dataProvider invalid_meetingid_provider
      * @param string $meetingid
+     * @covers ::get_from_meetingid
      */
     public function test_get_from_meetingid_invalid(string $meetingid): void {
         $this->expectException(moodle_exception::class);
@@ -146,6 +178,11 @@ class instance_test extends advanced_testcase {
         ];
     }
 
+    /**
+     * Test the get_all_instances_in_course function.
+     *
+     * @covers ::get_all_instances_in_course
+     */
     public function test_get_all_instances_in_course(): void {
         $this->resetAfterTest();
 
@@ -184,6 +221,11 @@ class instance_test extends advanced_testcase {
         ];
     }
 
+    /**
+     * Test the get_meeting_id function for a meeting configured for a group.
+     *
+     * @covers ::get_meeting_id
+     */
     public function test_get_meeting_id_with_groups(): void {
         $this->resetAfterTest();
 

--- a/tests/lib_test.php
+++ b/tests/lib_test.php
@@ -118,6 +118,8 @@ class lib_test extends testcase_helper {
 
     public function test_bigbluebuttonbn_reset_course_form_definition() {
         global $CFG, $PAGE;
+        $this->require_mock_server();
+
         $PAGE->set_course($this->course);
         $this->setAdminUser();
         $this->resetAfterTest();
@@ -194,6 +196,8 @@ class lib_test extends testcase_helper {
 
     public function test_mod_bigbluebuttonbn_core_calendar_provide_event_action() {
         global $DB;
+
+        $this->require_mock_server();
         $this->resetAfterTest();
         $this->setAdminUser();
         list($bbactivitycontext, $bbactivitycm, $bbactivity) = $this->create_instance();

--- a/tests/lib_test.php
+++ b/tests/lib_test.php
@@ -47,6 +47,9 @@ require_once($CFG->dirroot . '/mod/bigbluebuttonbn/lib.php');
  */
 class lib_test extends testcase_helper {
 
+    /**
+     * @covers ::bigbluebuttonbn_supports
+     */
     public function test_bigbluebuttonbn_supports() {
         $this->resetAfterTest();
         $this->assertTrue(bigbluebuttonbn_supports(FEATURE_IDNUMBER));
@@ -54,6 +57,9 @@ class lib_test extends testcase_helper {
         $this->assertFalse(bigbluebuttonbn_supports(FEATURE_GRADE_HAS_GRADE));
     }
 
+    /**
+     * @covers ::bigbluebuttonbn_add_instance
+     */
     public function test_bigbluebuttonbn_add_instance() {
         $this->resetAfterTest();
         list($bbactivitycontext, $bbactivitycm, $bbactivity) = $this->create_instance();
@@ -62,6 +68,9 @@ class lib_test extends testcase_helper {
         $this->assertNotNull($id);
     }
 
+    /**
+     * @covers ::bigbluebuttonbn_update_instance
+     */
     public function test_bigbluebuttonbn_update_instance() {
         $this->resetAfterTest();
         list($bbactivitycontext, $bbactivitycm, $bbactivity) = $this->create_instance();
@@ -70,6 +79,9 @@ class lib_test extends testcase_helper {
         $this->assertTrue($result);
     }
 
+    /**
+     * @covers ::bigbluebuttonbn_delete_instance
+     */
     public function test_bigbluebuttonbn_delete_instance() {
         $this->resetAfterTest();
         list($bbactivitycontext, $bbactivitycm, $bbactivity) = $this->create_instance();
@@ -77,6 +89,9 @@ class lib_test extends testcase_helper {
         $this->assertTrue($result);
     }
 
+    /**
+     * @covers ::bigbluebuttonbn_user_outline
+     */
     public function test_bigbluebuttonbn_user_outline() {
         $this->resetAfterTest();
         $user = $this->generator->create_user();
@@ -96,6 +111,9 @@ class lib_test extends testcase_helper {
         $this->assertMatchesRegularExpression('/.* has joined the session for 2 times/', $result);
     }
 
+    /**
+     * @covers ::bigbluebuttonbn_user_complete
+     */
     public function test_bigbluebuttonbn_user_complete() {
         $this->resetAfterTest();
         $user = $this->generator->create_user();
@@ -111,11 +129,17 @@ class lib_test extends testcase_helper {
         $this->assertEquals(2, $result);
     }
 
+    /**
+     * @covers ::bigbluebuttonbn_get_extra_capabilities
+     */
     public function test_bigbluebuttonbn_get_extra_capabilities() {
         $this->resetAfterTest();
         $this->assertEquals(array('moodle/site:accessallgroups'), bigbluebuttonbn_get_extra_capabilities());
     }
 
+    /**
+     * @covers ::bigbluebuttonbn_reset_course_form_definition
+     */
     public function test_bigbluebuttonbn_reset_course_form_definition() {
         global $CFG, $PAGE;
         $this->require_mock_server();
@@ -141,6 +165,9 @@ class lib_test extends testcase_helper {
         $this->assertNotNull($mform->getElement('bigbluebuttonbnheader'));
     }
 
+    /**
+     * @covers ::bigbluebuttonbn_reset_course_form_defaults
+     */
     public function test_bigbluebuttonbn_reset_course_form_defaults() {
         global $CFG;
         $this->resetAfterTest();
@@ -153,6 +180,9 @@ class lib_test extends testcase_helper {
         ), $results);
     }
 
+    /**
+     * @covers ::bigbluebuttonbn_reset_userdata
+     */
     public function test_bigbluebuttonbn_reset_userdata() {
         global $CFG;
         $this->resetAfterTest();
@@ -170,6 +200,9 @@ class lib_test extends testcase_helper {
         ), $results[0]);
     }
 
+    /**
+     * @covers ::bigbluebuttonbn_get_coursemodule_info
+     */
     public function test_bigbluebuttonbn_get_coursemodule_info() {
         $this->resetAfterTest();
         list($bbactivitycontext, $bbactivitycm, $bbactivity) = $this->create_instance();
@@ -177,6 +210,9 @@ class lib_test extends testcase_helper {
         $this->assertEquals($info->name, $bbactivity->name);
     }
 
+    /**
+     * @covers ::bigbluebuttonbn_check_updates_since
+     */
     public function test_bigbluebuttonbn_check_updates_since() {
         $this->resetAfterTest();
         list($bbactivitycontext, $bbactivitycm, $bbactivity) = $this->create_instance();
@@ -188,12 +224,18 @@ class lib_test extends testcase_helper {
         );
     }
 
+    /**
+     * @covers ::mod_bigbluebuttonbn_get_fontawesome_icon_map
+     */
     public function test_mod_bigbluebuttonbn_get_fontawesome_icon_map() {
         $this->resetAfterTest();
         $this->assertEquals(array('mod_bigbluebuttonbn:icon' => 'icon-bigbluebutton'),
             mod_bigbluebuttonbn_get_fontawesome_icon_map());
     }
 
+    /**
+     * @covers ::mod_bigbluebuttonbn_core_calendar_provide_event_action
+     */
     public function test_mod_bigbluebuttonbn_core_calendar_provide_event_action() {
         global $DB;
 
@@ -244,6 +286,8 @@ class lib_test extends testcase_helper {
 
     /**
      * Test setting navigation admin menu
+     *
+     * @covers ::bigbluebuttonbn_extend_settings_navigation
      */
     public function test_bigbluebuttonbn_extend_settings_navigation_admin() {
         global $PAGE, $CFG;
@@ -262,6 +306,9 @@ class lib_test extends testcase_helper {
         $this->assertCount(1, $node->get_children_key_list());
     }
 
+    /**
+     * @covers ::bigbluebuttonbn_extend_settings_navigation
+     */
     public function test_bigbluebuttonbn_extend_settings_navigation_user() {
         global $PAGE, $CFG;
         $this->resetAfterTest();

--- a/tests/local/bigbluebutton/recordings/recording_data_test.php
+++ b/tests/local/bigbluebutton/recordings/recording_data_test.php
@@ -1,0 +1,62 @@
+<?php
+// This file is part of Moodle - http://moodle.org/
+//
+// Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+
+/**
+ * Privacy provider tests.
+ *
+ * @package   mod_bigbluebuttonbn
+ * @copyright 2018 - present, Blindside Networks Inc
+ * @license   http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ * @author    Jesus Federico  (jesus [at] blindsidenetworks [dt] com)
+ */
+
+namespace mod_bigbluebuttonbn\local\bigbluebutton\recordings;
+
+use mod_bigbluebuttonbn\instance;
+
+/**
+ * Privacy provider tests class.
+ *
+ * @package   mod_bigbluebuttonbn
+ * @copyright 2018 - present, Blindside Networks Inc
+ * @license   http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ * @author    Jesus Federico  (jesus [at] blindsidenetworks [dt] com)
+ * @coversDefaultClass \mod_bigbluebuttonbn\local\bigbluebutton\recordings\recording_data
+ */
+class recording_data_test extends \advanced_testcase {
+
+    /**
+     * Test for the type_text provider.
+     *
+     * @covers ::type_text
+     * @dataProvider type_text_provider
+     * @param string $name
+     * @param string $type
+     */
+    public function test_get_recording_type_text(string $name, string $type) {
+        $this->assertEquals($name, recording_data::type_text($type));
+    }
+
+    public function type_text_provider(): array {
+        return [
+            ['Presentation', 'presentation'],
+            ['Video', 'video'],
+            ['Videos', 'videos'],
+            ['Whatever', 'whatever'],
+            ['Whatever It Can Be', 'whatever it can be'],
+        ];
+    }
+}

--- a/tests/local/bigbluebutton/recordings/recording_helper_test.php
+++ b/tests/local/bigbluebutton/recordings/recording_helper_test.php
@@ -1,0 +1,214 @@
+<?php
+// This file is part of Moodle - http://moodle.org/
+//
+// Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+
+/**
+ * Privacy provider tests.
+ *
+ * @package   mod_bigbluebuttonbn
+ * @copyright 2018 - present, Blindside Networks Inc
+ * @license   http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ * @author    Jesus Federico  (jesus [at] blindsidenetworks [dt] com)
+ */
+
+namespace mod_bigbluebuttonbn\local\bigbluebutton\recordings;
+
+use mod_bigbluebuttonbn\instance;
+
+/**
+ * Privacy provider tests class.
+ *
+ * @package   mod_bigbluebuttonbn
+ * @copyright 2018 - present, Blindside Networks Inc
+ * @license   http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ * @author    Jesus Federico  (jesus [at] blindsidenetworks [dt] com)
+ * @coversDefaultClass \mod_bigbluebuttonbn\local\bigbluebutton\recordings\recording_helper
+ * @covers \mod_bigbluebuttonbn\local\bigbluebutton\recordings\recording_helper
+ */
+class recording_helper_test extends \advanced_testcase {
+
+    public function setUp(): void {
+        parent::setUp();
+
+        $this->require_mock_server();
+        $this->getDataGenerator()->get_plugin_generator('mod_bigbluebuttonbn')->reset_mock();
+    }
+
+    protected function create_activity_with_recordings(int $type, int $recordingcount): array {
+        $this->resetAfterTest();
+
+        $generator = $this->getDataGenerator()->get_plugin_generator('mod_bigbluebuttonbn');
+
+        $course = $this->getDataGenerator()->create_course(['groupmodeforce' => true, 'groupmode' => VISIBLEGROUPS]);
+
+        $activity = $generator->create_instance([
+            'course' => $course->id,
+            'type' => $type,
+        ]);
+        $generator->create_meeting([
+            'instanceid' => $activity->id,
+        ]);
+
+        $recordings = [];
+        for ($i = 0; $i < $recordingcount; $i++) {
+            $recordings[] = $generator->create_recording([
+                'bigbluebuttonbnid' => $activity->id,
+                'name' => "Pre-Recording $i",
+            ]);
+        }
+
+        return [
+            'course' => $course,
+            'activity' => $activity,
+            'recordings' => $recordings,
+        ];
+    }
+
+    /**
+     * Test for bigbluebuttonbn_get_allrecordings()
+     *
+     * @param int $type The activity type
+     * @param int $recordingcount The amount of recordings to create
+     * @dataProvider get_allrecordings_provider
+     * @covers ::get_recordings_for_instance
+     */
+    public function test_get_allrecordings(int $type, int $recordingcount): void {
+        $this->resetAfterTest();
+
+        [
+            'activity' => $activity,
+            'course' => $course,
+        ] = $this->create_activity_with_recordings($type, $recordingcount);
+
+        // Fetch the recordings for the instance.
+        // The count shoudl match the input count.
+        $recordings = recording_helper::get_recordings_for_instance(instance::get_from_instanceid($activity->id));
+        $this->assertCount($recordingcount, $recordings);
+    }
+
+    public function get_allrecordings_provider(): array {
+        return [
+            [
+                'type' => instance::TYPE_ALL,
+                'recordingcount' => 2,
+            ],
+            [
+                'type' => instance::TYPE_ALL,
+                'recordingcount' => 3,
+            ],
+            [
+                'type' => instance::TYPE_RECORDING_ONLY,
+                'recordingcount' => 3,
+            ],
+        ];
+    }
+
+    /**
+     * Test for bigbluebuttonbn_get_allrecordings().
+     *
+     * TODO: rewrite this with @dataProvider
+     */
+    public function test_get_recording_for_group() {
+        $this->resetAfterTest(true);
+
+        $plugingenerator = $this->getDataGenerator()->get_plugin_generator('mod_bigbluebuttonbn');
+
+        $testcourse = $this->getDataGenerator()->create_course(['groupmodeforce' => true, 'groupmode' => VISIBLEGROUPS]);
+        $teacher = $this->getDataGenerator()->create_and_enrol($testcourse, 'editingteacher');
+
+        $group1 = $this->getDataGenerator()->create_group(['G1', 'courseid' => $testcourse->id]);
+        $student1 = $this->getDataGenerator()->create_and_enrol($testcourse);
+        $this->getDataGenerator()->create_group_member(['userid' => $student1, 'groupid' => $group1->id]);
+
+        $group2 = $this->getDataGenerator()->create_group(['G2', 'courseid' => $testcourse->id]);
+        $student2 = $this->getDataGenerator()->create_and_enrol($testcourse);
+        $this->getDataGenerator()->create_group_member(['userid' => $student2, 'groupid' => $group2->id]);
+
+        // No group.
+        $student3 = $this->getDataGenerator()->create_and_enrol($testcourse);
+
+        $activity = $plugingenerator->create_instance([
+            'course' => $testcourse->id,
+            'type' => instance::TYPE_ALL,
+            'name' => 'Example',
+        ]);
+        $plugingenerator->create_meeting([
+            'instanceid' => $activity->id,
+        ]);
+
+        // Create two recordings for all groups.
+        $plugingenerator->create_recording([
+            'bigbluebuttonbnid' => $activity->id,
+            'name' => "Pre-Recording 1",
+        ]);
+        $plugingenerator->create_recording([
+            'bigbluebuttonbnid' => $activity->id,
+            'name' => "Pre-Recording 2",
+        ]);
+
+        $plugingenerator->create_meeting([
+            'instanceid' => $activity->id,
+            'groupid' => $group1->id,
+        ]);
+        $recording1 = $plugingenerator->create_recording([
+            'bigbluebuttonbnid' => $activity->id,
+            'groupid' => $group1->id,
+            'name' => 'Group 1 Recording 1',
+        ]);
+
+        $plugingenerator->create_meeting([
+            'instanceid' => $activity->id,
+            'groupid' => $group2->id,
+        ]);
+        $recording2 = $plugingenerator->create_recording([
+            'bigbluebuttonbnid' => $activity->id,
+            'groupid' => $group2->id,
+            'name' => 'Group 2 Recording 1',
+        ]);
+
+        $this->setUser($student1);
+        $instance1 = instance::get_from_instanceid($activity->id);
+        $instance1->set_group_id($group1->id);
+        $recordings = recording_helper::get_recordings_for_instance($instance1);
+        $this->assertCount(1, $recordings);
+        $this->assertEquals('Group 1 Recording 1', $recordings[$recording1->id]->get('name'));
+
+        $this->setUser($student2);
+        $instance2 = instance::get_from_instanceid($activity->id);
+        $instance2->set_group_id($group2->id);
+        $recordings = recording_helper::get_recordings_for_instance($instance2);
+        $this->assertCount(1, $recordings);
+        $this->assertEquals('Group 2 Recording 1', $recordings[$recording2->id]->get('name'));
+
+        $this->setUser($student3);
+        $instance3 = instance::get_from_instanceid($activity->id);
+        $recordings = recording_helper::get_recordings_for_instance($instance3);
+        $this->assertIsArray($recordings);
+        $recordingnames = array_map(function($r) {
+            return $r->get('name');
+        }, $recordings);
+        $this->assertCount(4, $recordingnames);
+        $this->assertContains('Pre-Recording 1', $recordingnames);
+        $this->assertContains('Pre-Recording 2', $recordingnames);
+    }
+
+    protected function require_mock_server(): void {
+        if (!defined('TEST_MOD_BIGBLUEBUTTONBN_MOCK_SERVER')) {
+            $this->markTestSkipped(
+                'The TEST_MOD_BIGBLUEBUTTONBN_MOCK_SERVER constant must be defined to run mod_bigbluebuttonbn tests'
+            );
+        }
+    }
+}

--- a/tests/local/bigbluebutton/recordings/recording_test.php
+++ b/tests/local/bigbluebutton/recordings/recording_test.php
@@ -34,8 +34,11 @@ use mod_bigbluebuttonbn\instance;
  * @copyright 2018 - present, Blindside Networks Inc
  * @license   http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  * @author    Jesus Federico  (jesus [at] blindsidenetworks [dt] com)
+ * @covers \mod_bigbluebuttonbn\local\bigbluebutton\recordings\recording
+ * @coversDefaultClass \mod_bigbluebuttonbn\local\bigbluebutton\recordings\recording
  */
 class recording_test extends \advanced_testcase {
+
     public function setUp(): void {
         parent::setUp();
 
@@ -43,206 +46,75 @@ class recording_test extends \advanced_testcase {
         $this->getDataGenerator()->get_plugin_generator('mod_bigbluebuttonbn')->reset_mock();
     }
 
-    protected function setup_activities(): array {
+    protected function create_activity_with_recordings(int $type, array $recordingdata): array {
         $this->resetAfterTest();
-
-        $model = [
-            [
-                'courseindex' => 0,
-                'type' => instance::TYPE_ALL,
-                'recordingcount' => 2,
-            ],
-            [
-                'courseindex' => 0,
-                'type' => instance::TYPE_ALL,
-                'recordingcount' => 3,
-            ],
-            [
-                'courseindex' => 1,
-                'type' => instance::TYPE_RECORDING_ONLY,
-                'recordingcount' => 3,
-            ],
-        ];
 
         $generator = $this->getDataGenerator()->get_plugin_generator('mod_bigbluebuttonbn');
 
-        $courses = [
-            $this->getDataGenerator()->create_course(['groupmodeforce' => true, 'groupmode' => VISIBLEGROUPS]),
-            $this->getDataGenerator()->create_course(['groupmodeforce' => true, 'groupmode' => VISIBLEGROUPS]),
-        ];
+        $course = $this->getDataGenerator()->create_course(['groupmodeforce' => true, 'groupmode' => VISIBLEGROUPS]);
 
-        foreach ($model as $aname => $config) {
-            $activity = $generator->create_instance([
-                'course' => $courses[$config['courseindex']]->id,
-                'type' => $config['type'],
-                'name' => $aname
-            ]);
-            $generator->create_meeting([
-                'instanceid' => $activity->id,
-            ]);
+        $activity = $generator->create_instance([
+            'course' => $course->id,
+            'type' => $type,
+        ]);
+        $generator->create_meeting([
+            'instanceid' => $activity->id,
+        ]);
 
-            for ($recordingcount = 0; $recordingcount < $config['recordingcount']; $recordingcount++) {
-                $generator->create_recording([
-                    'bigbluebuttonbnid' => $activity->id,
-                    'name' => "Pre-Recording $recordingcount",
-                ]);
-            }
-            $activities[] = $activity;
+        $recordings = [];
+        $i = 0;
+        foreach ($recordingdata as $data) {
+            $recordings[] = $generator->create_recording(array_merge([
+                'bigbluebuttonbnid' => $activity->id,
+                'name' => "Pre-Recording $i",
+            ], $data));
+            $i++;
         }
 
         return [
-            'activities' => $activities,
-            'courses' => $courses,
+            'course' => $course,
+            'activity' => $activity,
+            'recordings' => $recordings,
         ];
-    }
-
-    /**
-     * Test for bigbluebuttonbn_get_allrecordings().
-     */
-    public function test_bigbluebuttonbn_get_allrecordings() {
-        [
-            'activities' => $activities,
-        ] = $this->setup_activities();
-
-        $recordings = recording_helper::get_recordings_for_instance(instance::get_from_instanceid($activities[0]->id));
-        $this->assertCount(2, $recordings);
-
-        $recordings = recording_helper::get_recordings_for_instance(instance::get_from_instanceid($activities[1]->id));
-        $this->assertCount(3, $recordings);
-
-        $recordings = recording_helper::get_recordings_for_instance(instance::get_from_instanceid($activities[2]->id));
-        $this->assertCount(3, $recordings);
     }
 
     /**
      * Test for bigbluebuttonbn_get_allrecordings status refresh.
-     */
-    public function test_bigbluebuttonbn_get_allrecordings_status_refresh() {
-        [
-            'activities' => $activities,
-        ] = $this->setup_activities();
-        $generator = $this->getDataGenerator()->get_plugin_generator('mod_bigbluebuttonbn');
-        $recording1 = $generator->create_recording([
-            'bigbluebuttonbnid' => $activities[0]->id,
-            'name' => "Pre-Recording should be refreshed",
-            'status' => recording::RECORDING_STATUS_AWAITING
-        ]);
-        $recording2 = $generator->create_recording([
-            'bigbluebuttonbnid' => $activities[0]->id,
-            'name' => "Pre-Recording should be visible",
-            'status' => recording::RECORDING_STATUS_DISMISSED
-        ]);
-        $this->assertEquals(recording::RECORDING_STATUS_AWAITING,
-            (new recording($recording1->id))->get('status'));
-        $this->assertEquals(recording::RECORDING_STATUS_DISMISSED,
-            (new recording($recording2->id))->get('status'));
-        $recordings = recording_helper::get_recordings_for_instance(instance::get_from_instanceid($activities[0]->id));
-        $this->assertCount(3, $recordings);
-
-        $this->assertEquals(recording::RECORDING_STATUS_PROCESSED,
-            (new recording($recording1->id))->get('status'));
-        $this->assertEquals(recording::RECORDING_STATUS_DISMISSED,
-            (new recording($recording2->id))->get('status'));
-    }
-
-    /**
-     * Test for bigbluebuttonbn_get_allrecordings().
      *
-     * TODO: rewrite this with @dataProvider
+     * @dataProvider get_status_provider
+     * @covers ::get
      */
-    public function test_bigbluebuttonbn_get_recording_for_group() {
-        $this->resetAfterTest(true);
+    public function test_get_allrecordings_status_refresh(int $status) {
+        ['recordings' => $recordings] = $this->create_activity_with_recordings(instance::TYPE_ALL, [['status' => $status]]);
 
-        $plugingenerator = $this->getDataGenerator()->get_plugin_generator('mod_bigbluebuttonbn');
-
-        $testcourse = $this->getDataGenerator()->create_course(['groupmodeforce' => true, 'groupmode' => VISIBLEGROUPS]);
-        $teacher = $this->getDataGenerator()->create_and_enrol($testcourse, 'editingteacher');
-
-        $group1 = $this->getDataGenerator()->create_group(['G1', 'courseid' => $testcourse->id]);
-        $student1 = $this->getDataGenerator()->create_and_enrol($testcourse);
-        $this->getDataGenerator()->create_group_member(['userid' => $student1, 'groupid' => $group1->id]);
-
-        $group2 = $this->getDataGenerator()->create_group(['G2', 'courseid' => $testcourse->id]);
-        $student2 = $this->getDataGenerator()->create_and_enrol($testcourse);
-        $this->getDataGenerator()->create_group_member(['userid' => $student2, 'groupid' => $group2->id]);
-
-        // No group.
-        $student3 = $this->getDataGenerator()->create_and_enrol($testcourse);
-
-        $activity = $plugingenerator->create_instance([
-            'course' => $testcourse->id,
-            'type' => instance::TYPE_ALL,
-            'name' => 'Example',
-        ]);
-        $plugingenerator->create_meeting([
-            'instanceid' => $activity->id,
-        ]);
-
-        // Create two recordings for all groups.
-        $plugingenerator->create_recording([
-            'bigbluebuttonbnid' => $activity->id,
-            'name' => "Pre-Recording 1",
-        ]);
-        $plugingenerator->create_recording([
-            'bigbluebuttonbnid' => $activity->id,
-            'name' => "Pre-Recording 2",
-        ]);
-
-        $plugingenerator->create_meeting([
-            'instanceid' => $activity->id,
-            'groupid' => $group1->id,
-        ]);
-        $recording1 = $plugingenerator->create_recording([
-            'bigbluebuttonbnid' => $activity->id,
-            'groupid' => $group1->id,
-            'name' => 'Group 1 Recording 1',
-        ]);
-
-        $plugingenerator->create_meeting([
-            'instanceid' => $activity->id,
-            'groupid' => $group2->id,
-        ]);
-        $recording2 = $plugingenerator->create_recording([
-            'bigbluebuttonbnid' => $activity->id,
-            'groupid' => $group2->id,
-            'name' => 'Group 2 Recording 1',
-        ]);
-
-        $this->setUser($student1);
-        $instance1 = instance::get_from_instanceid($activity->id);
-        $instance1->set_group_id($group1->id);
-        $recordings = recording_helper::get_recordings_for_instance($instance1);
-        $this->assertCount(1, $recordings);
-        $this->assertEquals('Group 1 Recording 1', $recordings[$recording1->id]->get('name'));
-
-        $this->setUser($student2);
-        $instance2 = instance::get_from_instanceid($activity->id);
-        $instance2->set_group_id($group2->id);
-        $recordings = recording_helper::get_recordings_for_instance($instance2);
-        $this->assertCount(1, $recordings);
-        $this->assertEquals('Group 2 Recording 1', $recordings[$recording2->id]->get('name'));
-
-        $this->setUser($student3);
-        $instance3 = instance::get_from_instanceid($activity->id);
-        $recordings = recording_helper::get_recordings_for_instance($instance3);
-        $this->assertIsArray($recordings);
-        $recordingnames = array_map(function($r) {
-            return $r->get('name');
-        }, $recordings);
-        $this->assertCount(4, $recordingnames);
-        $this->assertContains('Pre-Recording 1', $recordingnames);
-        $this->assertContains('Pre-Recording 2', $recordingnames);
+        $this->assertEquals($status, (new recording($recordings[0]->id))->get('status'));
     }
 
     /**
-     * Test for provider::get_metadata().
+     * @covers ::get_name
      */
-    public function test_bigbluebuttonbn_get_recording_type_text() {
-        $this->assertEquals('Presentation', recording_data::type_text('presentation'));
-        $this->assertEquals('Video', recording_data::type_text('video'));
-        $this->assertEquals('Videos', recording_data::type_text('videos'));
-        $this->assertEquals('Whatever', recording_data::type_text('whatever'));
-        $this->assertEquals('Whatever It Can Be', recording_data::type_text('whatever it can be'));
+    public function test_get_name(): void {
+        ['recordings' => $recordings] = $this->create_activity_with_recordings(instance::TYPE_ALL, [['name' => 'Example name']]);
+
+        $this->assertEquals('Example name', (new recording($recordings[0]->id))->get('name'));
+    }
+
+    /**
+     * @covers ::get_description
+     */
+    public function test_get_description(): void {
+        ['recordings' => $recordings] = $this->create_activity_with_recordings(instance::TYPE_ALL, [[
+            'description' => 'Example description',
+        ]]);
+
+        $this->assertEquals('Example description', (new recording($recordings[0]->id))->get('description'));
+    }
+
+    public function get_status_provider(): array {
+        return [
+            [recording::RECORDING_STATUS_PROCESSED],
+            [recording::RECORDING_STATUS_DISMISSED],
+        ];
     }
 
     protected function require_mock_server(): void {

--- a/tests/local/bigbluebutton/recordings/recording_test.php
+++ b/tests/local/bigbluebutton/recordings/recording_test.php
@@ -36,10 +36,10 @@ use mod_bigbluebuttonbn\instance;
  * @author    Jesus Federico  (jesus [at] blindsidenetworks [dt] com)
  */
 class recording_test extends \advanced_testcase {
-
     public function setUp(): void {
         parent::setUp();
 
+        $this->require_mock_server();
         $this->getDataGenerator()->get_plugin_generator('mod_bigbluebuttonbn')->reset_mock();
     }
 
@@ -243,5 +243,13 @@ class recording_test extends \advanced_testcase {
         $this->assertEquals('Videos', recording_data::type_text('videos'));
         $this->assertEquals('Whatever', recording_data::type_text('whatever'));
         $this->assertEquals('Whatever It Can Be', recording_data::type_text('whatever it can be'));
+    }
+
+    protected function require_mock_server(): void {
+        if (!defined('TEST_MOD_BIGBLUEBUTTONBN_MOCK_SERVER')) {
+            $this->markTestSkipped(
+                'The TEST_MOD_BIGBLUEBUTTONBN_MOCK_SERVER constant must be defined to run mod_bigbluebuttonbn tests'
+            );
+        }
     }
 }

--- a/tests/local/helpers/files_test.php
+++ b/tests/local/helpers/files_test.php
@@ -39,12 +39,13 @@ use stored_file;
  * @copyright 2018 - present, Blindside Networks Inc
  * @license   http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  * @author    Laurent David (laurent@call-learning.fr)
+ * @covers \mod_bigbluebuttonbn\local\helpers\files
+ * @coversDefaultClass \mod_bigbluebuttonbn\local\helpers\files
  */
 class files_test extends testcase_helper {
 
     /**
      * Plugin valid test case
-     *
      */
     public function test_bigbluebuttonbn_pluginfile_valid() {
         $this->resetAfterTest();
@@ -55,7 +56,6 @@ class files_test extends testcase_helper {
 
     /**
      * Plugin file test case
-     *
      */
     public function test_bigbluebuttonbn_pluginfile_file() {
         $this->resetAfterTest();
@@ -91,7 +91,6 @@ class files_test extends testcase_helper {
 
     /**
      * Get presentation file
-     *
      */
     public function test_bigbluebuttonbn_default_presentation_get_file() {
         $this->resetAfterTest();
@@ -112,7 +111,6 @@ class files_test extends testcase_helper {
 
     /**
      * Get filename test
-     *
      */
     public function test_bigbluebuttonbn_pluginfile_filename() {
         $this->resetAfterTest();
@@ -130,7 +128,6 @@ class files_test extends testcase_helper {
 
     /**
      * Get media files
-     *
      */
     public function test_bigbluebuttonbn_get_media_file() {
         $this->resetAfterTest();

--- a/tests/local/helpers/mod_helper_test.php
+++ b/tests/local/helpers/mod_helper_test.php
@@ -34,12 +34,13 @@ use mod_bigbluebuttonbn\test\testcase_helper;
  * @copyright 2018 - present, Blindside Networks Inc
  * @license   http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  * @author    Laurent David (laurent@call-learning.fr)
+ * @covers \mod_bigbluebuttonbn\local\helpers\mod_helper
+ * @coversDefaultClass \mod_bigbluebuttonbn\local\helpers\mod_helper
  */
 class mod_helper_test extends testcase_helper {
 
     /**
      * Presave test
-     *
      */
     public function test_bigbluebuttonbn_process_pre_save() {
         $this->resetAfterTest();
@@ -54,7 +55,6 @@ class mod_helper_test extends testcase_helper {
 
     /**
      * Presave instance
-     *
      */
     public function test_bigbluebuttonbn_process_pre_save_instance() {
         $this->resetAfterTest();
@@ -68,7 +68,6 @@ class mod_helper_test extends testcase_helper {
 
     /**
      * Presave checkboxes
-     *
      */
     public function test_bigbluebuttonbn_process_pre_save_checkboxes() {
         $this->resetAfterTest();
@@ -83,7 +82,6 @@ class mod_helper_test extends testcase_helper {
 
     /**
      * Presave common
-     *
      */
     public function test_bigbluebuttonbn_process_pre_save_common() {
         global $CFG;
@@ -100,7 +98,6 @@ class mod_helper_test extends testcase_helper {
 
     /**
      * Post save
-     *
      */
     public function test_bigbluebuttonbn_process_post_save() {
         global $CFG;
@@ -127,7 +124,6 @@ class mod_helper_test extends testcase_helper {
 
     /**
      * Post save notification
-     *
      */
     public function test_bigbluebuttonbn_process_post_save_notification() {
         $this->resetAfterTest();
@@ -151,7 +147,6 @@ class mod_helper_test extends testcase_helper {
 
     /**
      * Post save event
-     *
      */
     public function test_bigbluebuttonbn_process_post_save_event() {
         $this->resetAfterTest();
@@ -166,7 +161,6 @@ class mod_helper_test extends testcase_helper {
 
     /**
      * Post save completion
-     *
      */
     public function test_bigbluebuttonbn_process_post_save_completion() {
         $this->resetAfterTest();
@@ -178,5 +172,4 @@ class mod_helper_test extends testcase_helper {
         mod_helper::process_post_save($bbformdata);
         $this->assertNotEmpty($eventsink->get_events());
     }
-
 }

--- a/tests/local/helpers/reset_test.php
+++ b/tests/local/helpers/reset_test.php
@@ -36,6 +36,8 @@ use mod_bigbluebuttonbn\test\testcase_helper;
  * @copyright 2018 - present, Blindside Networks Inc
  * @license   http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  * @author    Laurent David (laurent@call-learning.fr)
+ * @coversDefaultClass \mod_bigbluebuttonbn\local\helpers\reset
+ * @covers \mod_bigbluebuttonbn\local\helpers\reset
  */
 class reset_test extends testcase_helper {
 

--- a/tests/local/helpers/roles_test.php
+++ b/tests/local/helpers/roles_test.php
@@ -34,6 +34,8 @@ use mod_bigbluebuttonbn\test\testcase_helper;
  * @copyright 2018 - present, Blindside Networks Inc
  * @license   http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  * @author    Laurent David (laurent@call-learning.fr)
+ * @covers \mod_bigbluebuttonbn\local\helpers\roles
+ * @coversDefaultClass \mod_bigbluebuttonbn\local\helpers\roles
  */
 class roles_test extends testcase_helper {
     /**

--- a/tests/local/notifier_test.php
+++ b/tests/local/notifier_test.php
@@ -35,11 +35,13 @@ use mod_bigbluebuttonbn\test\testcase_helper;
  * @copyright 2018 - present, Blindside Networks Inc
  * @license   http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  * @author    Laurent David (laurent@call-learning.fr)
+ * @coversDefaultClass \mod_bigbluebuttonbn\local\notifier
  */
 class notifier_test extends testcase_helper {
     /**
      * Test notificiation updated
      *
+     * @covers ::notify_instance_updated
      */
     public function test_notify_instance_updated() {
         global $DB;

--- a/tests/logger_test.php
+++ b/tests/logger_test.php
@@ -34,11 +34,12 @@ use mod_bigbluebuttonbn\test\testcase_helper;
  * @copyright 2018 - present, Blindside Networks Inc
  * @license   http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  * @author    Laurent David (laurent@call-learning.fr)
+ * @covers \mod_bigbluebuttonbn\logger
+ * @coversDefaultClass \mod_bigbluebuttonbn\logger
  */
 class logger_test extends testcase_helper {
     /**
      * Test delete instance logs
-     *
      */
     public function test_log_instance_deleted() {
         global $DB;
@@ -57,7 +58,7 @@ class logger_test extends testcase_helper {
     /**
      * Test log method
      */
-    public function test_bigbluebuttonbn_log() {
+    public function test_log_recording_played_event() {
         global $DB;
 
         $this->resetAfterTest();

--- a/tests/privacy/provider_test.php
+++ b/tests/privacy/provider_test.php
@@ -24,9 +24,6 @@
  */
 namespace mod_bigbluebuttonbn\privacy;
 
-defined('MOODLE_INTERNAL') || die();
-global $CFG;
-
 use context_module;
 use core_privacy\local\metadata\collection;
 use core_privacy\local\request\approved_contextlist;
@@ -40,11 +37,9 @@ use core_privacy\local\request\userlist;
  * @copyright 2018 - present, Blindside Networks Inc
  * @license   http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  * @author    Jesus Federico  (jesus [at] blindsidenetworks [dt] com)
+ * @covers \mod_bigbluebuttonbn\privacy\provider
  */
 class provider_test extends \core_privacy\tests\provider_testcase {
-    /**
-     * Setup Course
-     */
 
     /**
      * Test for provider::get_metadata().


### PR DESCRIPTION
These changes include:
* switch back to my mock server image to support parallel behat runs
* Fix GHA to allow the mock container to access the behat host
* Fix behat tests to work with new navigation on moodle master branch for 4.0
* Ensure that remote tests are skipped if the remote server is not defined
* Fix code coverage generation to only report lines which are intentionally tested

Suggest picking these commits without merge commit.