### PR TITLE
CONTRIB-8660: Add more tests for instance

### DIFF
--- a/classes/instance.php
+++ b/classes/instance.php
@@ -428,11 +428,7 @@ EOF;
             $groupid = $this->get_group_id();
         }
 
-        if ($groupid === null) {
-            return $baseid;
-        } else {
-            return sprintf('%s[%s]', $baseid, $groupid);
-        }
+        return sprintf('%s[%s]', $baseid, $groupid);
     }
 
     /**
@@ -775,18 +771,11 @@ EOF;
      */
     public function allow_recording_start_stop(): bool {
         if (!$this->is_recorded()) {
+            // If the meeting is not configured for recordings, do not allow it to be recorded.
             return false;
         }
 
-        if (!$this->should_record_from_start()) {
-            return true;
-        }
-
-        if ($this->should_show_recording_button()) {
-            return true;
-        }
-
-        return false;
+        return $this->should_show_recording_button();
     }
 
     /**
@@ -860,7 +849,7 @@ EOF;
             return false;
         }
 
-        return $closingtime <= time();
+        return $closingtime < time();
     }
 
     /**
@@ -1050,28 +1039,5 @@ EOF;
      */
     public function should_record() {
         return (boolean) config::recordings_enabled() && $this->is_recorded();
-    }
-
-
-    /**
-     * Check if room is available
-     *
-     */
-    public function is_room_available() {
-        $open = true;
-        $closed = false;
-        $timenow = time();
-        $timeopen = $this->get_instance_var('openingtime');
-        $timeclose = $this->get_instance_var('closingtime');
-        if (!empty($timeopen) && $timeopen > $timenow) {
-            $open = false;
-        }
-        if (!empty($timeclose) && $timenow > $timeclose) {
-            $closed = true;
-        }
-        if (!$open || $closed) {
-            return false;
-        }
-        return true;
     }
 }

--- a/classes/meeting.php
+++ b/classes/meeting.php
@@ -231,7 +231,7 @@ class meeting {
                 $meetinginfo->canjoin = true;
             }
         }
-        if ($instance->is_room_available() && $instance->user_can_force_join()) {
+        if ($instance->is_currently_open() && $instance->user_can_force_join()) {
             $meetinginfo->canjoin = true;
         }
         // Double check that the user has the capabilities to join.

--- a/lib.php
+++ b/lib.php
@@ -462,7 +462,7 @@ function mod_bigbluebuttonbn_core_calendar_provide_event_action(
     $usercomplete = bigbluebuttonbn_user_complete($event->courseid, $event->userid, $bigbluebuttonbn);
     $instance = instance::get_from_instanceid($bigbluebuttonbn->id);
     // Get if the room is available.
-    $roomavailable = $instance->is_room_available();
+    $roomavailable = $instance->is_currently_open();
     // Get if the user can join.
     $meetinginfo = meeting::get_meeting_info_for_instance($instance);
     $usercanjoin = $meetinginfo->canjoin;


### PR DESCRIPTION
It appears we have a few bugs. I don't know the solution - these need
your input:
* allow_start_stop_recording when the recording is started at meeting
  creation does not behave as I would expect.
* is_room_available duplicates behaviour of is_currently_open.
  Personally I prefer is_currently_open because it is clearer to read
  and understand.