### PR TITLE
CONTRIB-8660: Move completion to custom_completion class

### DIFF
--- a/classes/external/completion_validate.php
+++ b/classes/external/completion_validate.php
@@ -20,8 +20,8 @@ use external_api;
 use external_function_parameters;
 use external_single_structure;
 use external_value;
+use mod_bigbluebuttonbn\completion\custom_completion;
 use mod_bigbluebuttonbn\instance;
-use mod_bigbluebuttonbn\local\proxy\bigbluebutton_proxy;
 use moodle_exception;
 
 /**
@@ -73,7 +73,7 @@ class completion_validate extends external_api {
         $users = get_enrolled_users($context, 'mod/bigbluebuttonbn:view', 0, 'u.*', $sort);
         foreach ($users as $user) {
             // Enqueue a task for processing the completion.
-            bigbluebutton_proxy::enqueue_completion_event( $instance->get_instance_data(), $user->id);
+            custom_completion::enqueue_completion_event( $instance->get_instance_data(), $user->id);
         }
         // We might want to return a status here or some warnings.
         return [];

--- a/classes/local/proxy/bigbluebutton_proxy.php
+++ b/classes/local/proxy/bigbluebutton_proxy.php
@@ -205,58 +205,6 @@ class bigbluebutton_proxy extends proxy_base {
     }
 
     /**
-     * Helper function enqueues one user for being validated as for completion.
-     *
-     * @param object $bigbluebuttonbn
-     * @param string $userid
-     * @return void
-     */
-    public static function enqueue_completion_event($bigbluebuttonbn, $userid): void {
-        try {
-            // Create the instance of completion_update_state task.
-            $task = new \mod_bigbluebuttonbn\task\completion_update_state();
-            // Add custom data.
-            $data = array(
-                'bigbluebuttonbn' => $bigbluebuttonbn,
-                'userid' => $userid,
-            );
-            $task->set_custom_data($data);
-            // CONTRIB-7457: Task should be executed by a user, maybe Teacher as Student won't have rights for overriding.
-            // $ task -> set_userid ( $ user -> id );.
-            // Enqueue it.
-            \core\task\manager::queue_adhoc_task($task);
-        } catch (Exception $e) {
-            mtrace("Error while enqueuing completion_update_state task. " . (string) $e);
-        }
-    }
-
-    /**
-     * Helper function enqueues completion trigger.
-     *
-     * @param object $bigbluebuttonbn
-     * @param string $userid
-     * @return void
-     */
-    public static function update_completion_state($bigbluebuttonbn, $userid) {
-        global $CFG;
-        require_once($CFG->libdir . '/completionlib.php');
-        list($course, $cm) = get_course_and_cm_from_instance($bigbluebuttonbn, 'bigbluebuttonbn');
-        $completion = new completion_info($course);
-        if (!$completion->is_enabled($cm)) {
-            mtrace("Completion not enabled");
-            return;
-        }
-
-        $bbbcompletion = new custom_completion($cm, $userid);
-        if ($bbbcompletion->get_overall_completion_state()) {
-            mtrace("Completion succeeded for user $userid");
-            $completion->update_state($cm, COMPLETION_COMPLETE, $userid, true);
-        } else {
-            mtrace("Completion did not succeed for user $userid");
-        }
-    }
-
-    /**
      * Helper function returns an array with the profiles (with features per profile) for the different types
      * of bigbluebuttonbn instances.
      *

--- a/classes/meeting.php
+++ b/classes/meeting.php
@@ -20,6 +20,7 @@ use cache;
 use cache_store;
 use core_tag_tag;
 use Exception;
+use mod_bigbluebuttonbn\completion\custom_completion;
 use mod_bigbluebuttonbn\local\config;
 use mod_bigbluebuttonbn\local\exceptions\bigbluebutton_exception;
 use mod_bigbluebuttonbn\local\exceptions\server_not_available_exception;
@@ -462,7 +463,7 @@ class meeting {
             logger::log_event_summary($instance, $overrides, $meta);
 
             // Enqueue a task for processing the completion.
-            bigbluebutton_proxy::enqueue_completion_event($instance->get_instance_data(), $userid);
+            custom_completion::enqueue_completion_event($instance->get_instance_data(), $userid);
         }
     }
 

--- a/classes/task/completion_update_state.php
+++ b/classes/task/completion_update_state.php
@@ -17,7 +17,7 @@
 namespace mod_bigbluebuttonbn\task;
 
 use core\task\adhoc_task;
-use mod_bigbluebuttonbn\local\proxy\bigbluebutton_proxy;
+use mod_bigbluebuttonbn\completion\custom_completion;
 
 /**
  * Class containing the scheduled task for lti module.
@@ -31,11 +31,13 @@ class completion_update_state extends adhoc_task {
      * Run bigbluebuttonbn cron.
      */
     public function execute() {
+        global $USER;
+
         // Get the custom data.
         $data = $this->get_custom_data();
-        mtrace("Task completion_update_state running for user {$data->userid}");
+        mtrace("Task completion_update_state running for user {$USER->id}");
 
         // Process the completion.
-        bigbluebutton_proxy::update_completion_state($data->bigbluebuttonbn, $data->userid);
+        custom_completion::update_completion_state($data->bigbluebuttonbn);
     }
 }

--- a/db/upgrade.php
+++ b/db/upgrade.php
@@ -395,6 +395,22 @@ function xmldb_bigbluebuttonbn_upgrade($oldversion = 0) {
         upgrade_mod_savepoint(true, 2021083100, 'bigbluebuttonbn');
     }
 
+    if ($oldversion < 2021090100) {
+        $rs = $DB->get_recordset('task_adhoc', 'classname', '\mod_bigbluebuttonbn\task\custom_completion');
+        foreach ($rs as $row) {
+            $customdata = json_decode($row->customdata);
+            if (property_exists($customdata, 'userid')) {
+                $DB->set_field('task_adhoc', 'userid', $customdata->userid, ['id' => $row->id]);
+            } else {
+                $DB->delete_records('task_adhoc', ['id' => $row->id]);
+            }
+        }
+        $rs->close();
+
+        // Bigbluebuttonbn savepoint reached.
+        upgrade_mod_savepoint(true, 2021090100, 'bigbluebuttonbn');
+    }
+
     return true;
 }
 

--- a/version.php
+++ b/version.php
@@ -26,7 +26,7 @@
 
 defined('MOODLE_INTERNAL') || die;
 
-$plugin->version = 2021083100;
+$plugin->version = 2021000100;
 $plugin->requires = 2020061500;
 $plugin->cron = 0;
 $plugin->component = 'mod_bigbluebuttonbn';


### PR DESCRIPTION
This takes the completion parts out of the bbb proxy, and puts them straight into the custom_completion class.

This simplifies the bbb proxy (which should only be used for remote calls to fetch data from the BBB API).

This is a WIP as I need to test it all, and test the upgrade step (manual testing).