### PR TITLE
CONTRIB-8660: Fix behat skip tests

### DIFF
--- a/classes/local/proxy/proxy_base.php
+++ b/classes/local/proxy/proxy_base.php
@@ -73,7 +73,7 @@ abstract class proxy_base {
      */
     protected static function sanitized_url() {
         $serverurl = trim(config::get('server_url'));
-        if (defined('BEHAT_SITE_RUNNING') || PHPUNIT_TEST) {
+        if (PHPUNIT_TEST) {
             $serverurl = (new moodle_url(TEST_MOD_BIGBLUEBUTTONBN_MOCK_SERVER))->out(false);
         }
         if (substr($serverurl, -1) == '/') {

--- a/tests/behat/add_instance.feature
+++ b/tests/behat/add_instance.feature
@@ -5,7 +5,8 @@ Feature: bigbluebuttonbn instance
   I need to add three room activities to an existent course
 
   Background:  Make sure that a course is created
-    Given the following "courses" exist:
+    Given a BigBlueButton mock server is configured
+    And the following "courses" exist:
       | fullname    | shortname   | category |
       | Test course | Test course | 0        |
 

--- a/tests/behat/behat_mod_bigbluebuttonbn.php
+++ b/tests/behat/behat_mod_bigbluebuttonbn.php
@@ -43,13 +43,24 @@ class behat_mod_bigbluebuttonbn extends behat_base {
      * @BeforeScenario @mod_bigbluebuttonbn
      */
     public function before_scenario(BeforeScenarioScope $scope) {
+        if (defined('TEST_MOD_BIGBLUEBUTTONBN_MOCK_SERVER')) {
+            $this->send_mock_request('backoffice/reset');
+        }
+    }
+
+    /**
+     * Ensure that it is possible to connect to a bbb mock server.
+     *
+     * @Given /^a BigBlueButton mock server is configured$/
+     */
+    public function mock_is_configured(): void {
         if (!defined('TEST_MOD_BIGBLUEBUTTONBN_MOCK_SERVER')) {
             throw new SkippedException(
                 'The TEST_MOD_BIGBLUEBUTTONBN_MOCK_SERVER constant must be defined to run mod_bigbluebuttonbn tests'
             );
         }
 
-        $this->send_mock_request('backoffice/reset');
+        set_config('bigbluebuttonbn_server_url', TEST_MOD_BIGBLUEBUTTONBN_MOCK_SERVER);
     }
 
     /**

--- a/tests/behat/end_meeting.feature
+++ b/tests/behat/end_meeting.feature
@@ -4,6 +4,9 @@ Feature: Test the ability to end a meeting
   As a teacher
   I need to control who can end a meeting
 
+  Background:
+    Given a BigBlueButton mock server is configured
+
   Scenario Outline: Only a BigBlueButton moderator can end a session
     Given the following course exists:
       | name      | Test course |

--- a/tests/behat/group_mode.feature
+++ b/tests/behat/group_mode.feature
@@ -3,7 +3,8 @@ Feature: Test the module in group mode.
 
   Background:
     # 1 = separate groups, we force the group
-    Given the following "courses" exist:
+    Given a BigBlueButton mock server is configured
+    And the following "courses" exist:
       | fullname      | shortname | category | groupmode | groupmodeforce |
       | Test Course 1 | C1        | 0        | 1         | 1              |
     And the following "groups" exist:

--- a/tests/behat/installed.feature
+++ b/tests/behat/installed.feature
@@ -4,6 +4,9 @@ Feature: Installation succeeds
   As a user
   I need the installation to work
 
+  Background:
+    Given a BigBlueButton mock server is configured
+
   Scenario: Check the Plugins overview for the name of this plugin
     When I log in as "admin"
     And I navigate to "Plugins > Plugins overview" in site administration

--- a/tests/behat/join_meeting.feature
+++ b/tests/behat/join_meeting.feature
@@ -2,6 +2,9 @@
 Feature: Test the ability to run the full meeting lifecycle (start to end)
   I can start a meeting then end it
 
+  Background:
+    Given a BigBlueButton mock server is configured
+
   Scenario: Users should be able to join a meeting then end the meeting for themselves and
     return to the meeting page to join again.
     Given the following course exists:

--- a/tests/behat/meeting_roles.feature
+++ b/tests/behat/meeting_roles.feature
@@ -4,6 +4,9 @@ Feature: Test that meeting roles are sent to the server
   As a teacher
   I need meeting roles to be sent to the meeting
 
+  Background:
+    Given a BigBlueButton mock server is configured
+
   @javascript
   Scenario Outline: Users should receive the appropriate role when joining the meeting
     Given the following course exists:

--- a/tests/behat/recordings.feature
+++ b/tests/behat/recordings.feature
@@ -3,7 +3,8 @@ Feature: The recording can be managed through the room page
   As a user I am able to see the relevant recording for a given bigbluebutton activity and modify its parameters
 
   Background:  Make sure that import recording is enabled and course, activities and recording exists
-    Given the following "courses" exist:
+    Given a BigBlueButton mock server is configured
+    And the following "courses" exist:
       | fullname      | shortname | category |
       | Test Course 1 | C1        | 0        |
       | Test Course 2 | C2        | 0        |

--- a/tests/behat/recordings_import.feature
+++ b/tests/behat/recordings_import.feature
@@ -3,7 +3,8 @@ Feature: Manage and list recordings
   As a user I am able to import existing recording into another bigbluebutton activity
 
   Background:  Make sure that import recording is enabled and course, activities and recording exists
-    Given the following config values are set as admin:
+    Given a BigBlueButton mock server is configured
+    And the following config values are set as admin:
       | bigbluebuttonbn_importrecordings_enabled | 1 |
     And the following "courses" exist:
       | fullname      | shortname | category |

--- a/tests/behat/start_meeting.feature
+++ b/tests/behat/start_meeting.feature
@@ -4,6 +4,9 @@ Feature: Test the ability to start a meeting
   As a teacher
   I need to control who can start a meeting
 
+  Background:
+    Given a BigBlueButton mock server is configured
+
   Scenario Outline: Users should be able to join a session depending on the Wait for moderator to join setting
     Given the following course exists:
       | name      | Test course |


### PR DESCRIPTION
A long-standing behat bug prevents tests from being marked as skipped in
a BeforeScenario (https://github.com/Behat/Behat/pull/1214) without
causing the entire suite to be re-run.

This fix adds a step to the background of every feature to allow it to
check that setup is complete.