### PR TITLE
Fix fatal errors when referencing missing class names

### DIFF
--- a/mod_form.php
+++ b/mod_form.php
@@ -51,7 +51,6 @@ class mod_bigbluebuttonbn_mod_form extends moodleform_mod {
         if (is_null($serverversion)) {
             throw new moodle_exception('general_error_unable_connect', plugin::COMPONENT,
                 $CFG->wwwroot.'/admin/settings.php?section=modsettingbigbluebuttonbn');
-            return;
         }
         $bigbluebuttonbn = null;
         if ($this->current->id) {
@@ -81,7 +80,6 @@ class mod_bigbluebuttonbn_mod_form extends moodleform_mod {
             if (empty($jsvars['instanceTypeProfiles'])) {
                 throw new moodle_exception('general_error_not_allowed_to_create_instances)', plugin::COMPONENT,
                     $CFG->wwwroot.'/admin/settings.php?section=modsettingbigbluebuttonbn');
-                return;
             }
         }
         $jsvars['instanceTypeDefault'] = array_keys($jsvars['instanceTypeProfiles'])[0];

--- a/mod_form.php
+++ b/mod_form.php
@@ -24,6 +24,9 @@
  * @author    Fred Dixon  (ffdixon [at] blindsidenetworks [dt] com)
  */
 
+use mod_bigbluebuttonbn\locallib\config;
+use mod_bigbluebuttonbn\plugin;
+
 defined('MOODLE_INTERNAL') || die();
 
 require_once(dirname(__FILE__).'/locallib.php');
@@ -57,7 +60,7 @@ class mod_bigbluebuttonbn_mod_form extends moodleform_mod {
             $bigbluebuttonbn = $DB->get_record('bigbluebuttonbn', array('id' => $this->current->id), '*', MUST_EXIST);
         }
         // UI configuration options.
-        $cfg = \mod_bigbluebuttonbn\locallib\config::get_options();
+        $cfg = config::get_options();
 
         $jsvars = array();
 
@@ -154,7 +157,7 @@ class mod_bigbluebuttonbn_mod_form extends moodleform_mod {
      *
      * @param array $data
      * @param array $files
-     * @return void
+     * @return array
      */
     public function validation($data, $files) {
         $errors = parent::validation($data, $files);
@@ -180,7 +183,7 @@ class mod_bigbluebuttonbn_mod_form extends moodleform_mod {
      */
     public function add_completion_rules() {
         $mform = $this->_form;
-        if (!(boolean)\mod_bigbluebuttonbn\locallib\config::get('meetingevents_enabled')) {
+        if (!(boolean) config::get('meetingevents_enabled')) {
             return [];
         }
 
@@ -257,7 +260,7 @@ class mod_bigbluebuttonbn_mod_form extends moodleform_mod {
      * @return void
      */
     private function bigbluebuttonbn_mform_add_block_profiles(&$mform, $profiles) {
-        if ((boolean)\mod_bigbluebuttonbn\locallib\config::recordings_enabled()) {
+        if ((boolean) config::recordings_enabled()) {
             $mform->addElement('select', 'type', get_string('mod_form_field_instanceprofiles', 'bigbluebuttonbn'),
                 bigbluebuttonbn_get_instance_profiles_array($profiles),
                 array('onchange' => 'M.mod_bigbluebuttonbn.modform.updateInstanceTypeProfile(this);'));


### PR DESCRIPTION
Some class name references do not use FQ class names in BBB activity form. When referenced by php interpreter Moodle crashes with a fatal error that does not reveal primary cause of problem.
Additionally a few minor changes were made with phpdoc and unreachable return statements.