### PR TITLE
CONTRIB-8694: Multiple fixes

### DIFF
--- a/classes/logger.php
+++ b/classes/logger.php
@@ -179,26 +179,6 @@ class logger {
     }
 
     /**
-     * Log the relevant events for when a meeting was created.
-     *
-     * @param instance $instance
-     */
-    public static function log_meeting_created_event(instance $instance): void {
-        // Moodle event logger: Create an event for meeting created.
-        self::log_moodle_event($instance, events::$events['meeting_create']);
-
-        // Internal logger: Insert a record with the meeting created.
-        self::log(
-            $instance,
-            self::EVENT_CREATE,
-            ['meetingid' => $instance->get_meeting_id()],
-            json_encode((object) [
-                'record' => $instance->is_recorded() ? 'true' : 'false',
-            ])
-        );
-    }
-
-    /**
      * Log the events for when a meeting was ended.
      *
      * @param instance $instance

--- a/classes/meeting.php
+++ b/classes/meeting.php
@@ -181,8 +181,6 @@ class meeting {
             );
             $recording->create();
         }
-        // Moodle event logger: Create an event for meeting created.
-        logger::log_meeting_created_event($this->instance);
         return $response;
     }
 

--- a/tests/external/view_bigbluebuttonbn_test.php
+++ b/tests/external/view_bigbluebuttonbn_test.php
@@ -20,6 +20,7 @@ use external_api;
 use mod_bigbluebuttonbn\instance;
 use mod_bigbluebuttonbn\test\testcase_helper_trait;
 use moodle_exception;
+use require_login_exception;
 
 defined('MOODLE_INTERNAL') || die();
 
@@ -80,11 +81,8 @@ class view_bigbluebuttonbn_test extends \externallib_advanced_testcase {
         $course = $this->getDataGenerator()->create_course();
         $record = $this->getDataGenerator()->create_module('bigbluebuttonbn', ['course' => $course->id]);
         $instance = instance::get_from_instanceid($record->id);
-
-        $returnvalue = $this->view_bigbluebuttonbn($instance->get_cm_id());
-        $this->assertArrayHasKey('status', $returnvalue);
-        $this->assertArrayHasKey('warnings', $returnvalue);
-        $this->assertFalse($returnvalue['status']);
+        $this->expectException(require_login_exception::class);
+        $this->view_bigbluebuttonbn($instance->get_instance_id());
     }
 
     /**
@@ -98,13 +96,10 @@ class view_bigbluebuttonbn_test extends \externallib_advanced_testcase {
         $record = $generator->create_module('bigbluebuttonbn', ['course' => $course->id]);
         $instance = instance::get_from_instanceid($record->id);
 
-        $user = $generator->create_user();
+        $user = $generator->create_user($course);
         $this->setUser($user);
-
-        $returnvalue = $this->view_bigbluebuttonbn($instance->get_cm_id());
-        $this->assertArrayHasKey('status', $returnvalue);
-        $this->assertArrayHasKey('warnings', $returnvalue);
-        $this->assertFalse($returnvalue['status']);
+        $this->expectException(require_login_exception::class);
+        $this->view_bigbluebuttonbn($instance->get_instance_id());
     }
 
     /**
@@ -121,11 +116,11 @@ class view_bigbluebuttonbn_test extends \externallib_advanced_testcase {
         $user = $generator->create_and_enrol($course, 'student');
         $this->setUser($user);
 
-        $returnvalue = $this->view_bigbluebuttonbn($instance->get_cm_id());
+        $returnvalue = $this->view_bigbluebuttonbn($instance->get_instance_id());
 
         $this->assertArrayHasKey('status', $returnvalue);
         $this->assertArrayHasKey('warnings', $returnvalue);
-        $this->assertFalse($returnvalue['status']);
+        $this->assertTrue($returnvalue['status']);
     }
 }
 


### PR DESCRIPTION
* The view_bigbluebuttonbn_test testcase were wrong and the require_login was never called (this on postgres + mysql) because we  were looking at the cmid instead of the instance id. However on MSSQL as cmid = instanceid, the test failed.
* Fixed the test so they test the adequate workflow (we need to be logged and access the activity to use the view_bigbluebuttonbn API)
* Remove the "Create" event log
