### PR TITLE
CONTRIB-8660: Use events for cache purging

### DIFF
--- a/classes/settings.php
+++ b/classes/settings.php
@@ -27,7 +27,7 @@ use admin_setting_configtext;
 use admin_setting_configtextarea;
 use admin_setting_heading;
 use admin_settingpage;
-use cache;
+use cache_helper;
 use lang_string;
 use mod_bigbluebuttonbn\local\config;
 use mod_bigbluebuttonbn\local\helpers\roles;
@@ -1280,10 +1280,6 @@ class settings {
      */
     protected function reset_cache() {
         // Reset serverinfo cache.
-        $cache = cache::make('mod_bigbluebuttonbn', 'serverinfo');
-        $cache->purge();
-        // Reset recording cache.
-        $cache = cache::make('mod_bigbluebuttonbn', 'recordings');
-        $cache->purge();
+        cache_helper::purge_by_event('mod_bigbluebuttonbn/serversettingschanged');
     }
 }

--- a/db/caches.php
+++ b/db/caches.php
@@ -30,6 +30,9 @@ $definitions = [
     // version  (double) => server version.
     'serverinfo' => [
         'mode' => cache_store::MODE_APPLICATION,
+        'invalidationevents' => [
+            'mod_bigbluebuttonbn/serversettingschanged',
+        ],
     ],
 
     // The validatedurls cache stores a list of URLs which are either valid, or invalid.
@@ -45,6 +48,7 @@ $definitions = [
         'mode' => cache_store::MODE_APPLICATION,
         'invalidationevents' => [
             'mod_bigbluebuttonbn/recordingchanged',
+            'mod_bigbluebuttonbn/serversettingschanged',
         ],
         'ttl' => HOURSECS,
     ],


### PR DESCRIPTION
It is much better to use cache invalidation/purging than creating the caches and purging them manually. The code which invalidates the cache should not need to know which caches it has to invalidate - the caches are a function of the code using them, not unrelated code.