### PR TITLE
Send user avatar when they join a meeting

### DIFF
--- a/classes/instance.php
+++ b/classes/instance.php
@@ -27,6 +27,8 @@ use mod_bigbluebuttonbn\local\proxy\bigbluebutton_proxy;
 use moodle_url;
 use stdClass;
 
+require_once("{$CFG->libdir}/filelib.php");
+
 /**
  * Instance record for mod_bigbluebuttonbn.
  *
@@ -567,6 +569,24 @@ EOF;
 
         return fullname($user);
     }
+
+    /**
+     * Get the avatar url for the current user.
+     * $size = 'large' => 'f1', 'small' => 'f2';
+     *
+     * @return string
+     */
+    public function get_user_avatar_url($size='f2'): string {
+        $user = $this->get_user();
+
+        $src = null;
+        if ($user->picture) {
+           $src = get_file_url($user->id.'/'.$size.'.jpg', null, 'user');
+        }
+
+        return $src;
+    }
+
 
     /**
      * Whether the current user is an administrator.

--- a/classes/local/proxy/bigbluebutton_proxy.php
+++ b/classes/local/proxy/bigbluebutton_proxy.php
@@ -65,7 +65,8 @@ class bigbluebutton_proxy extends proxy_base {
         string $logouturl,
         string $configtoken = null,
         string $userid = null,
-        string $createtime = null
+        string $createtime = null,
+        string $avatarurl = null
     ): ?string {
         $data = [
             'meetingID' => $meetingid,
@@ -84,6 +85,10 @@ class bigbluebutton_proxy extends proxy_base {
 
         if (!is_null($createtime)) {
             $data['createTime'] = $createtime;
+        }
+
+        if (!is_null($avatarurl)) {
+            $data['avatarURL'] = $avatarurl;
         }
 
         return self::action_url('join', $data);

--- a/classes/meeting.php
+++ b/classes/meeting.php
@@ -205,7 +205,8 @@ class meeting {
             $this->instance->get_logout_url()->out(false),
             null,
             $this->instance->get_user_id(),
-            $this->get_meeting_info()->createtime
+            $this->get_meeting_info()->createtime,
+            $this->instance->get_user_avatar_url()
         );
     }
 


### PR DESCRIPTION
This wip pr checks for existence of [user picture](https://github.com/moodle/moodle/blob/e5894c04553e04563d60ccc435f00adaac62e854/lib/classes/user.php#L694) in Moodle. If it exists the picture url is generated and will be sent as `avatarURL` when calling [join endpoint](https://docs.bigbluebutton.org/dev/api.html#join).
 
Resolves https://github.com/blindsidenetworks/moodle-mod_bigbluebuttonbn/issues/303