### PR TITLE
MDL-70658: Fix room information display

### DIFF
--- a/classes/meeting.php
+++ b/classes/meeting.php
@@ -269,7 +269,7 @@ class meeting {
             $meetinginfo->startedat = floor(intval($info['startTime']) / 1000); // Milliseconds.
             $meetinginfo->moderatorcount = $info['moderatorCount'];
             $meetinginfo->moderatorplural = $info['moderatorCount'] > 1;
-            $meetinginfo->participantcount = $info['participantCount'] ?? 0;
+            $meetinginfo->participantcount = $participantcount - $meetinginfo->moderatorcount;
             $meetinginfo->participantplural = $meetinginfo->participantcount > 1;
         } else {
             if ($instance->user_must_wait_to_join() && !$instance->user_can_force_join()) {
@@ -520,7 +520,7 @@ class meeting {
         logger::log_meeting_joined_event($this->instance, $origin);
 
         // Before executing the redirect, increment the number of participants.
-        roles::participant_joined($this->instance->get_meeting_id(), $this->instance->does_current_user_count_towards_user_limit());
+        roles::participant_joined($this->instance->get_meeting_id(), $this->instance->is_moderator());
         return $this->get_join_url();
     }
 }

--- a/templates/room_view.mustache
+++ b/templates/room_view.mustache
@@ -58,34 +58,13 @@
             <span>
                 {{#viewerplural}}{{#str}}view_message_viewers, mod_bigbluebuttonbn{{/str}}{{/viewerplural}}
                 {{^viewerplural}}{{#str}}view_message_viewer, mod_bigbluebuttonbn{{/str}}{{/viewerplural}}
-                <strong>{{participantcount}}</strong>
+                <strong>{{participantcount}}</strong>.
             </span>
         </div>
         {{/statusrunning}}
     </span>
 
-    <span id="control_panel">
-    </span>
-
     <div id="room_view_control_panel" data-bbb-id="{{bigbluebuttonbnid}}">
-        {{#starttime}}
-            <span>{{#str}}view_message_session_started_at, mod_bigbluebuttonbn, {{startTime}}{{/str}}</span>
-        {{/starttime}}
-        {{#attendees}}
-            {{^participants}}
-                <span>{{#str}}view_message_session_no_users, mod_bigbluebuttonbn{{/str}}</span>
-            {{/participants}}
-            {{^onemoderators}}
-                <span>{{#str}}view_message_moderators, mod_bigbluebuttonbn{{/str}}</span>
-            {{/onemoderators}}
-            {{#onemoderators}}
-                <span>{{#str}}view_message_moderator, mod_bigbluebuttonbn{{/str}}</span>
-            {{/onemoderators}}
-            <span>{{fullName}}</span>
-            {{#isrunning}}
-                <span></span>
-            {{/isrunning}}
-        {{/attendees}}
         {{#haspresentations}}
             <h4>{{#str}}view_section_title_presentation, mod_bigbluebuttonbn{{/str}}</h4>
             <div class="list-group list-group-flush">

--- a/tests/meeting_test.php
+++ b/tests/meeting_test.php
@@ -225,13 +225,41 @@ class meeting_test extends \advanced_testcase {
         $meeting->update_cache();
         $this->assertCount(1, $meeting->get_attendees());
         $otheruser = $this->getDataGenerator()->create_and_enrol($this->get_course());
-        $this->setUser($useringroup);
+        $this->setUser($otheruser);
         $meeting->update_cache();
         $this->join_meeting($meeting->join(logger::ORIGIN_BASE));
         $meeting->update_cache();
         $this->assertCount(2, $meeting->get_attendees());
     }
 
+    /**
+     * Test that attendees returns the right list of attendees
+     *
+     * @covers ::get_attendees
+     */
+    public function test_participant_count() {
+        $this->resetAfterTest();
+        [$meeting, $useringroup, $usernotingroup, $groupid, $activity] =
+            $this->prepare_meeting(instance::TYPE_ALL, null, NOGROUPS, true);
+        $this->setUser($useringroup);
+        $this->join_meeting($meeting->join(logger::ORIGIN_BASE));
+        $meeting->update_cache();
+        $meetinginfo = $meeting->get_meeting_info();
+        $this->assertEquals(1, $meetinginfo->participantcount);
+        $this->assertEquals(0, $meetinginfo->moderatorcount);
+        $this->setUser($usernotingroup);
+        $this->join_meeting($meeting->join(logger::ORIGIN_BASE));
+        $meeting->update_cache();
+        $meetinginfo = $meeting->get_meeting_info();
+        $this->assertEquals(2, $meetinginfo->participantcount);
+        $this->assertEquals(0, $meetinginfo->moderatorcount);
+        $this->setAdminUser();
+        $this->join_meeting($meeting->join(logger::ORIGIN_BASE));
+        $meeting->update_cache();
+        $meetinginfo = $meeting->get_meeting_info();
+        $this->assertEquals(2, $meetinginfo->participantcount);
+        $this->assertEquals(1, $meetinginfo->moderatorcount);
+    }
     /**
      * Send a join meeting API CALL
      *


### PR DESCRIPTION
* Fix room template to reflect information returned by get_meeting_info
* Fix number of viewer (total participant - moderators)
* Fix and add further test related to participant count. The number of participants/viewers counted by the mock server was different from the one counted by the real server as it included moderators + participants.