### PR TITLE
MDL-70658: Fix issue with completion groups when meetingevents disabled

### DIFF
--- a/mod_form.php
+++ b/mod_form.php
@@ -706,9 +706,11 @@ class mod_bigbluebuttonbn_mod_form extends moodleform_mod {
         if ($completion->is_enabled()) {
             $mform = $this->_form;
             foreach (['completionattendancegroup', 'completionengagementgroup'] as $groupname) {
-                $element = $mform->getElement($groupname);
-                if ($element->isFrozen()) {
-                    $element->unfreeze();
+                if ($mform->elementExists($groupname)) {
+                    $element = $mform->getElement($groupname);
+                    if ($element->isFrozen()) {
+                        $element->unfreeze();
+                    }
                 }
             }
         }


### PR DESCRIPTION
* The fix applied previously for mod_form and completionattendancegroup,
completionengagementgroup was throwing an exception when
bigbluebuttonbn_meetingevents_enabled is disabled