### PR TITLE
Plugin-level scaling solution satisfying #536

### DIFF
--- a/classes/locallib/config.php
+++ b/classes/locallib/config.php
@@ -55,8 +55,7 @@ class config {
      */
     public static function defaultvalues() {
         return array(
-            'server_url' => (string) BIGBLUEBUTTONBN_DEFAULT_SERVER_URL,
-            'shared_secret' => (string) BIGBLUEBUTTONBN_DEFAULT_SHARED_SECRET,
+            'default_servers' => BIGBLUEBUTTONBN_DEFAULT_SERVERS,
             'voicebridge_editable' => false,
             'importrecordings_enabled' => false,
             'importrecordings_from_deleted_enabled' => false,

--- a/classes/locallib/mobileview.php
+++ b/classes/locallib/mobileview.php
@@ -47,9 +47,9 @@ class mobileview {
         if ($bbbsession['administrator'] || $bbbsession['moderator']) {
             $password = $bbbsession['modPW'];
         }
-        $joinurl = bigbluebuttonbn_get_join_url($bbbsession['meetingid'], $bbbsession['username'],
-            $password, $bbbsession['logoutURL'], null, $bbbsession['userID'], $bbbsession['clienttype'],
-            $bbbsession['createtime']);
+        $joinurl = bigbluebuttonbn_get_join_url($bbbsession['server'], $bbbsession['meetingid'],
+            $bbbsession['username'], $password, $bbbsession['logoutURL'], null,
+            $bbbsession['userID'], $bbbsession['clienttype'], $bbbsession['createtime']);
 
         return($joinurl);
     }

--- a/classes/output/index.php
+++ b/classes/output/index.php
@@ -115,15 +115,17 @@ class index implements renderable {
      * @return array
      */
     public static function bigbluebuttonbn_index_display_room($moderator, $course, $bigbluebuttonbn, $groupobj = null) {
+        global $DB;
         $meetingid = sprintf('%s-%d-%d', $bigbluebuttonbn->meetingid, $course->id, $bigbluebuttonbn->id);
         $groupname = '';
+        $server = $DB->get_record('bigbluebuttonbn_servers', ['servername' => $bigbluebuttonbn->servername]);
         $urlparams = ['id' => $bigbluebuttonbn->coursemodule];
         if ($groupobj) {
             $meetingid .= sprintf('[%d]', $groupobj->id);
             $urlparams['group'] = $groupobj->id;
             $groupname = $groupobj->name;
         }
-        $meetinginfo = bigbluebuttonbn_get_meeting_info_array($meetingid);
+        $meetinginfo = bigbluebuttonbn_get_meeting_info_array($server, $meetingid);
         if (empty($meetinginfo)) {
             // The server was unreachable.
             print_error('index_error_unable_display', plugin::COMPONENT);

--- a/classes/output/mobile.php
+++ b/classes/output/mobile.php
@@ -54,7 +54,7 @@ class mobile {
      */
     public static function mobile_course_view($args) {
 
-        global $OUTPUT, $SESSION;
+        global $DB, $OUTPUT, $SESSION;
 
         $args = (object) $args;
         $viewinstance = bigbluebuttonbn_view_validator($args->cmid, null);
@@ -68,6 +68,7 @@ class mobile {
         // Create variables for easy access.
         $bigbluebuttonbn = $viewinstance['bigbluebuttonbn'];
         $serverversion = $bbbsession['serverversion'];
+        $bbbsession['server'] = $DB->get_record('bigbluebuttonbn_servers', ['servername' => $bigbluebuttonbn->servername]);
         $cm = $bbbsession['cm'];
         $course = $bbbsession['course'];
         $context = $bbbsession['context'];
@@ -141,10 +142,11 @@ class mobile {
         }
 
         // See if the BBB session is already in progress.
-        if (!bigbluebuttonbn_is_meeting_running($bbbsession['meetingid'])) {
+        if (!bigbluebuttonbn_is_meeting_running($bbbsession['server'], $bbbsession['meetingid'])) {
 
             // The meeting doesnt exist in BBB server, must be created.
             $response = bigbluebuttonbn_get_create_meeting_array(
+                $bbbsession['server'],
                 \mod_bigbluebuttonbn\locallib\mobileview::bigbluebutton_bbb_view_create_meeting_data($bbbsession),
                 \mod_bigbluebuttonbn\locallib\mobileview::bigbluebutton_bbb_view_create_meeting_metadata($bbbsession),
                 $bbbsession['presentation']['name'],
@@ -183,7 +185,7 @@ class mobile {
 
         // It is part of 'bigbluebutton_bbb_view_join_meeting' in bbb_view.
         // Update the cache.
-        $meetinginfo = bigbluebuttonbn_get_meeting_info($bbbsession['meetingid'], BIGBLUEBUTTONBN_UPDATE_CACHE);
+        $meetinginfo = bigbluebuttonbn_get_meeting_info($bbbsession['server'], $bbbsession['meetingid'], BIGBLUEBUTTONBN_UPDATE_CACHE);
         if ($bbbsession['userlimit'] > 0 && intval($meetinginfo['participantCount']) >= $bbbsession['userlimit']) {
             // No more users allowed to join.
             $message = get_string('view_error_userlimit_reached', 'bigbluebuttonbn');

--- a/classes/settings/admin_setting_servers.php
+++ b/classes/settings/admin_setting_servers.php
@@ -1,0 +1,202 @@
+<?php
+
+namespace mod_bigbluebuttonbn\settings;
+require_once $GLOBALS['CFG']->dirroot . '/lib/adminlib.php';
+require_once __DIR__ . "/../../db/upgrade.php";
+
+use admin_setting_configtextarea;
+
+/**
+ * This abstract class intend to be an input form to get list of bigbluebuttonbn servers
+ *
+ * @package  mod_bigbluebuttonbn
+ * @copyright 2022, Sajad Khosravani S. sajadkhosravani1@gmail.com
+ * @author Sajad Khosravani S.
+ */
+class admin_setting_servers extends admin_setting_configtextarea
+{
+    protected $servers;
+
+    public function __construct($name)
+    {
+        parent::__construct("bigbluebuttonbn_$name",
+            get_string('config_servers', 'bigbluebuttonbn'),
+            get_string('config_servers_description', 'bigbluebuttonbn'),
+            get_string('config_servers_default', 'bigbluebuttonbn'),
+            PARAM_RAW,35,10);
+    }
+
+    public static function instance($name){
+        return new self($name);
+    }
+
+    /**
+     * Trim values of array
+     * @param array $server
+     */
+    public static function clean_up(array &$server)
+    {
+        foreach ($server as $key => &$value) {
+            $value = trim($value);
+        }
+    }
+
+    /**
+     * Validate content after submit
+     *
+     * @param string $data
+     * @return bool|\lang_string|mixed|string
+     */
+    public function validate($data)
+    {
+        $validated = parent::validate($data);
+        if ($validated !== true)
+            return $validated;
+
+        $validated = $this->validate_servers($data);
+        if ($validated !== true)
+            return $validated;
+
+        return true;
+    }
+
+    /**
+     * Validate and parse servers data and initialize $this->servers
+     *
+     * @param string $data
+     * @return bool|\lang_string|string
+     * @throws \coding_exception
+     */
+    public function validate_servers($data)
+    {
+        // To json format
+        $servers = json_decode($data, true);
+        if (is_null($servers))
+            return get_string('error_format_json', 'bigbluebuttonbn');
+
+        // Validate each server
+        $this->servers = array();
+        foreach($servers as $server){
+            self::clean_up($server);
+            $validated = self::validate_server($server);
+            if ($validated !== true)
+                return $validated;
+            $this->servers[] = (object) $server;
+        }
+
+        // Check if default server is not set or is set more than one time
+        $defaultsCount = 0;
+        foreach ($servers as $server) {
+            if (key_exists('default', $server) and $server['default'] === true)
+                $defaultsCount++;
+        }
+        if ($defaultsCount > 1) {
+            return get_string('error_default_server_count_more_than_one',
+                'bigbluebuttonbn');
+        }else if ($defaultsCount < 1) {
+            return get_string('error_no_default_server',
+                'bigbluebuttonbn');
+        }
+
+        // Check if on of servers' name is repetitive
+        $names = array();
+        foreach ($servers as $server) {
+            @$names[$server['servername']]++;
+        }
+        foreach ($names as $servername => $count) {
+            if ($count > 1)
+                return sprintf(get_string('error_repetitive_servername', 'bigbluebuttonbn'),
+                    $servername, $count);
+        }
+        return true;
+    }
+
+    /**
+     * Validate a single server array. Called only by 'validate_servers' function.
+     *
+     * @param array $server
+     * @return bool|string
+     * @throws \coding_exception
+     */
+    public static function validate_server(array $server)
+    {
+        // Make sure all fields have been defined
+        $requiredFields = ['servername', 'url', 'secret', 'cap_users', 'cap_sessions'];
+        foreach ($requiredFields as $field)
+            if (!key_exists($field, $server))
+                return sprintf(get_string('error_field_required','bigbluebuttonbn'),
+                    $field);
+
+        // Check if servername is not allowed
+        if (trim($server['servername']) === FILLING_SERVER_NAME)
+            return sprintf(get_string('error_forbidden_servername', 'bigbluebuttonbn'),
+                FILLING_SERVER_NAME);
+
+        // Check if server is available
+        $version = bigbluebuttonbn_get_server_version((object)$server);
+        if (is_null($version)){
+            return sprintf(get_string('error_server_unavailable', 'bigbluebuttonbn'),
+                $server['servername']);
+        }
+
+        return true;
+    }
+
+    /**
+     * Sync the table 'bigbluebuttonbn_servers' with newly-defined servers
+     *
+     * @throws \dml_exception
+     */
+    public function update_servers(){
+        global $DB;
+        // Delete unmentioned servers
+        $servernames = array();
+        foreach ($this->servers as $server) {
+            $servernames[] = $server->servername;
+        }
+        foreach ($DB->get_records('bigbluebuttonbn_servers') as $server) {
+            if (!in_array($server->servername, $servernames)) {
+                $DB->delete_records('bigbluebuttonbn_servers', ['servername' => $server->servername]);
+            }
+        }
+
+        // Insert or update servers
+        foreach ($this->servers as $server){
+            if ($server->default)
+                $defaultServerName = $server->servername;
+            if ($server->id = $DB->get_field('bigbluebuttonbn_servers', 'id', ['servername' => $server->servername])){
+                $DB->update_record('bigbluebuttonbn_servers', $server);
+            } else {
+                $DB->insert_record('bigbluebuttonbn_servers', $server);
+            }
+        }
+
+        // Set default server
+        set_config('bigbluebuttonbn_default_server_name', $defaultServerName);
+
+        // Substitute filing servername with default server if exist
+        $DB->execute("
+            UPDATE {`bigbluebuttonbn`} SET servername=\"$defaultServerName\" WHERE servername=\"".FILLING_SERVER_NAME."\""
+        );
+    }
+
+    /**
+     * Inherited from parent class
+     *
+     * @param mixed $data
+     * @return bool|\lang_string|mixed|string
+     * @throws \coding_exception
+     */
+    public function write_setting($data) {
+        try {
+            $validated = $this->validate($data);
+            if ($validated !== true) {
+                return $validated;
+            }
+            $this->update_servers();
+        } catch (\Exception $exception) {
+            return $exception->getMessage();
+        }
+        return ($this->config_write($this->name, $data) ? '' : get_string('errorsetting', 'admin'));
+    }
+}

--- a/classes/settings/renderer.php
+++ b/classes/settings/renderer.php
@@ -24,6 +24,7 @@
  */
 
 namespace mod_bigbluebuttonbn\settings;
+require_once "admin_setting_servers.php";
 
 defined('MOODLE_INTERNAL') || die();
 

--- a/classes/settings/validator.php
+++ b/classes/settings/validator.php
@@ -45,8 +45,8 @@ class validator {
      */
     public static function section_general_shown() {
         global $CFG;
-        return (!isset($CFG->bigbluebuttonbn['server_url']) ||
-                !isset($CFG->bigbluebuttonbn['shared_secret']));
+        return (!isset($CFG->bigbluebuttonbn['servers']) ||
+                !isset($CFG->bigbluebuttonbn['server_selection_method']));
     }
 
     /**

--- a/config-dist.php
+++ b/config-dist.php
@@ -31,10 +31,10 @@ global $CFG;
  * This file should be renamed to "config.php" in the plugin directory
  *
  * It is intended to be used for setting configuration by default and
- * also for enable/diable configuration options in the admin setting UI
+ * also for enable/disable configuration options in the admin setting UI
  * for those multitenancy deployments where the admin account is given
  * to the tenant owner and some shared information like the
- * bigbluebutton_server_url and bigbluebutton_shared_secret must been
+ * servers url and shared secrets must been
  * kept private. And also when some of the features are going to be
  * disabled for all the tenants in that server
  **/
@@ -61,8 +61,7 @@ global $CFG;
  * Networks that you can use for testing.
  **/
 
-$CFG->bigbluebuttonbn['server_url'] = 'http://test-install.blindsidenetworks.com/bigbluebutton/';
-$CFG->bigbluebuttonbn['shared_secret'] = '8cd8ef52e8e101574e400365b55e11a6';
+$CFG->bigbluebuttonbn['default_servers'] = BIGBLUEBUTTONBN_DEFAULT_SERVERS;
 
 /*
  * 1.2. CONFIGURATION FOR "RECORDING" FEATURE

--- a/db/install.xml
+++ b/db/install.xml
@@ -8,6 +8,7 @@
     <TABLE NAME="bigbluebuttonbn" COMMENT="The bigbluebuttonbn table to store information about a meeting activities.">
       <FIELDS>
         <FIELD NAME="id" TYPE="int" LENGTH="10" NOTNULL="true" SEQUENCE="true"/>
+        <FIELD NAME="servername" TYPE="char" LENGTH="128" NOTNULL="true" SEQUENCE="false"/>
         <FIELD NAME="type" TYPE="int" LENGTH="2" NOTNULL="true" DEFAULT="0" SEQUENCE="false"/>
         <FIELD NAME="course" TYPE="int" LENGTH="10" NOTNULL="true" DEFAULT="0" SEQUENCE="false"/>
         <FIELD NAME="name" TYPE="char" LENGTH="255" NOTNULL="true" SEQUENCE="false"/>
@@ -61,5 +62,23 @@
         <INDEX NAME="userlog" UNIQUE="false" FIELDS="userid, log"/>
       </INDEXES>
     </TABLE>
+
+    <TABLE NAME="bigbluebuttonbn_servers" COMMENT="The bigbluebuttonbn table to store servers' details">
+      <FIELDS>
+        <FIELD NAME="id" TYPE="int" LENGTH="10" NOTNULL="true" SEQUENCE="true"/>
+        <FIELD NAME="servername" TYPE="char" LENGTH="128" NOTNULL="true" SEQUENCE="false"/> <!-- unique -->
+        <FIELD NAME="url" TYPE="char" LENGTH="512" NOTNULL="true" SEQUENCE="false"/>
+        <FIELD NAME="secret" TYPE="char" LENGTH="256" NOTNULL="true" SEQUENCE="false"/>
+        <FIELD NAME="cap_sessions" TYPE="int" LENGTH="10" NOTNULL="true" SEQUENCE="false"/>
+        <FIELD NAME="cap_users" TYPE="int" LENGTH="10" NOTNULL="true" SEQUENCE="false"/>
+      </FIELDS>
+      <KEYS>
+        <KEY NAME="primary" TYPE="primary" FIELDS="id"/>
+      </KEYS>
+      <INDEXES>
+        <INDEX NAME="servername-unique" UNIQUE="true" FIELDS="servername"/>
+      </INDEXES>
+    </TABLE>
+
   </TABLES>
 </XMLDB>

--- a/db/upgrade.php
+++ b/db/upgrade.php
@@ -28,6 +28,8 @@ defined('MOODLE_INTERNAL') || die();
 
 require_once(dirname(dirname(__FILE__)).'/locallib.php');
 
+define('FILLING_SERVER_NAME', 'DEFAULT_DEFAULT_DEFAULT_DEFAULT_DEFAULT_DEFAULT');
+
 /**
  * Performs data migrations and updates on upgrade.
  *
@@ -205,6 +207,22 @@ function xmldb_bigbluebuttonbn_upgrade($oldversion = 0) {
         upgrade_mod_savepoint(true, 2019042012, 'bigbluebuttonbn');
     }
 
+    if ($oldversion < 2022010100) {
+        $newTable = new xmldb_table('bigbluebuttonbn_servers');
+        $newTable->add_field('id', XMLDB_TYPE_INTEGER, 10, true, true, true);
+        $newTable->add_key('primary', XMLDB_KEY_PRIMARY, ['id']);
+        $newTable->add_field('servername', XMLDB_TYPE_CHAR, 128, null, true, false);
+        $newTable->add_key('servername-unique', XMLDB_KEY_UNIQUE, ['servername']);
+        $newTable->add_field('url', XMLDB_TYPE_CHAR, 512, null, true, false);
+        $newTable->add_field('secret', XMLDB_TYPE_CHAR, 256, null, true, false);
+        $newTable->add_field('cap_sessions', XMLDB_TYPE_INTEGER, 10, true, true, false);
+        $newTable->add_field('cap_users', XMLDB_TYPE_INTEGER, 10, true, true, false);
+        $dbman->create_table($newTable);
+        xmldb_bigbluebuttonbn_add_change_field($dbman, 'bigbluebuttonbn', 'servername', [
+            'type' => XMLDB_TYPE_CHAR, 'precision' => 128, 'unsigned' => null, 'notnull' => true,
+            'sequence' => false, 'default' => FILLING_SERVER_NAME, 'previous' => 'id'
+        ]);
+    }
     return true;
 }
 

--- a/index.php
+++ b/index.php
@@ -54,6 +54,7 @@ $action = optional_param('action', '', PARAM_TEXT);
 if ($action === 'end') {
     // A request to end the meeting.
     $bigbluebuttonbn = $DB->get_record('bigbluebuttonbn', ['id' => $a]);
+    $server = $DB->get_record('bigbluebuttonbn_servers', ['servername' => $bigbluebuttonbn->servername]);
     if (!$bigbluebuttonbn) {
         print_error('index_error_bbtn', plugin::COMPONENT, '', $a);
     }
@@ -71,7 +72,7 @@ if ($action === 'end') {
             $meetingid .= sprintf('[%d]', $g);
         }
 
-        bigbluebuttonbn_end_meeting($meetingid, $bigbluebuttonbn->moderatorpass);
+        bigbluebuttonbn_end_meeting($server, $meetingid, $bigbluebuttonbn->moderatorpass);
         redirect($PAGE->url);
     }
 }

--- a/lang/en/bigbluebuttonbn.php
+++ b/lang/en/bigbluebuttonbn.php
@@ -487,7 +487,12 @@ $string['selected_server'] = "Selected server:";
 
 $string['config_servers'] = "Servers";
 $string['config_servers_description'] = "Fill list of the servers in JSON format. 
-Each server must contain these attributes: url, secret, cap_sessions, cap_users";
+Each server must contain these attributes:
+<li><b>url:</b> Address of the  bigbluebutton server in URL format.</li>
+<li><b>secret:</b> Shred secret of the bigbluebutton server</li>
+<li><b>cap_sessions:</b> relative number of sessions that the server can host</li>
+<li><b>cap_users:</b> relative number of sessions that the server can host</li>";
+
 $string['config_servers_default'] = "
 [
     {

--- a/lang/en/bigbluebuttonbn.php
+++ b/lang/en/bigbluebuttonbn.php
@@ -78,10 +78,6 @@ $string['privacy:metadata:bigbluebutton:fullname'] = 'The fullname of the user a
 
 $string['config_general'] = 'General configuration';
 $string['config_general_description'] = 'These settings are <b>always</b> used';
-$string['config_server_url'] = 'BigBlueButton Server URL';
-$string['config_server_url_description'] = 'The URL of your BigBlueButton server must end with /bigbluebutton/. (This default URL is for a BigBlueButton server provided by Blindside Networks that you can use for testing.)';
-$string['config_shared_secret'] = 'BigBlueButton Shared Secret';
-$string['config_shared_secret_description'] = 'The security salt of your BigBlueButton server.  (This default salt is for a BigBlueButton server provided by Blindside Networks that you can use for testing.)';
 
 $string['config_recording'] = 'Configuration for "Record meeting" feature';
 $string['config_recording_description'] = 'These settings are feature specific';
@@ -475,3 +471,38 @@ $string['index_error_bbtn'] = 'BigBlueButton ID {$a} is incorrect';
 
 $string['view_mobile_message_reload_page_creation_time_meeting'] = 'You exceeded the 45 seconds in this page, please reload the page to join correctly to the meeting.';
 $string['view_mobile_message_groups_not_supported'] = 'This instance is enable to work with groups but the mobile app has not support for this. Please open in desktop if you want to use the group support.';
+
+$string['error_format_json'] = "Wrong format! Please enter data in JSON format.";
+$string['error_default_server_count_more_than_one'] = "Default servers are more than one";
+$string['error_no_default_server'] = "One server must be defined as 'default' by adding a property with key=\"default\" and value=true to the intended server.";
+$string['error_repetitive_servername'] = "The servername '%s' has been defined %d times.";
+$string['error_field_required'] = "Each server object must include the property '%s'!";
+$string['error_forbidden_servername'] = "The name '%s' is not allowed to be assigned as a server's name";
+$string['error_server_unavailable'] = "Server '%s' is not available";
+
+$string['server_unavailable'] = "Server is Unavailable!";
+$string['server_available'] = "Server is available!<br>Server version: %s";
+$string['selected_server'] = "Selected server:";
+
+
+$string['config_servers'] = "Servers";
+$string['config_servers_description'] = "Fill list of the servers in JSON format. 
+Each server must contain these attributes: url, secret, cap_sessions, cap_users";
+$string['config_servers_default'] = "
+[
+    {
+        \"servername\": \"default\",
+        \"url\":\"http://test-install.blindsidenetworks.com/bigbluebutton/\",
+        \"default\": true,
+        \"secret\": \"8cd8ef52e8e101574e400365b55e11a6\",
+        \"cap_sessions\": 1,
+        \"cap_users\": 1
+    }
+]
+";
+
+$string['config_server_selection_method'] = 'Server selection method';
+$string['config_server_selection_method_description'] =
+    'Enter the method to select a server for a new session in an offline way.';
+$string['server_selection_method__users'] = 'Count of users on each server';
+$string['server_selection_method__sessions'] = 'Count of sessions on each server';

--- a/lang/fa/bigbluebuttonbn.php
+++ b/lang/fa/bigbluebuttonbn.php
@@ -1,0 +1,49 @@
+<?php
+// This file is part of Moodle - http://moodle.org/
+//
+// Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+
+/**
+ * Language File.
+ *
+ * @package   mod_bigbluebuttonbn
+ * @copyright 2010 onwards, Blindside Networks Inc
+ * @license   http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ * @author    Jesus Federico  (jesus [at] blindsidenetworks [dt] com)
+ * @author    Fred Dixon  (ffdixon [at] blindsidenetworks [dt] com)
+ */
+defined('MOODLE_INTERNAL') || die();
+
+$string['error_format_json'] = "فرمت اطلاعات اشتباه است! لطفا با فرمت JSON اطلاعات را وارد کنید.";
+$string['error_default_server_count_more_than_one'] = "بیش از یک سرور پیشفرض تعریف شده است.";
+$string['error_no_default_server'] = "یک سرور باید به عنوان پیشفرض در نظر گرفته شود. به این صورت که یک ویژگی با کلید \"default\"و مقدار true باید برای سرور مورد نظر تعریف شود.";
+$string['error_repetitive_servername'] = "نام سرور '%s'، بیش از یکبار (%d بار) تعریف شده.";
+$string['error_field_required'] = "هر سرور باید ویژگی '%s' را داشته باشد!";
+$string['error_forbidden_servername'] = "نام '%s' برای نام گزاری روی یک سرور مجاز نیست!";
+$string['error_server_unavailable'] = "سرور '%s' در دسترس نیست!";
+
+$string['server_unavailable'] = "سرور در دسترس نیست!";
+$string['server_available'] = "سرور در دسترس است!<br>نسخه ی سرور: %s";
+$string['selected_server'] = "سرور انتخاب شده:";
+
+
+$string['config_servers'] = "سرور ها";
+$string['config_servers_description'] = "لیست سرور ها را در فرمت JSON وارد کنید.
+هر سرور باید این ویژگی ها را داشته باشد: url, secret, cap_sessions, cap_users";
+
+$string['config_server_selection_method'] = 'روش انتخاب سرور';
+$string['config_server_selection_method_description'] =
+    'یک روش برای انتخاب سرور برای نشست های جدید انتخاب کنید.';
+$string['server_selection_method__users'] = 'شمار تعداد کاربران روی هر سرور';
+$string['server_selection_method__sessions'] = 'شمار تعداد نشست ها روی هر سرور';

--- a/lang/fa/bigbluebuttonbn.php
+++ b/lang/fa/bigbluebuttonbn.php
@@ -40,7 +40,11 @@ $string['selected_server'] = "سرور انتخاب شده:";
 
 $string['config_servers'] = "سرور ها";
 $string['config_servers_description'] = "لیست سرور ها را در فرمت JSON وارد کنید.
-هر سرور باید این ویژگی ها را داشته باشد: url, secret, cap_sessions, cap_users";
+هر سرور باید ویژگی های زیر را داشته باشد.
+<li><b>url:</b> آدرس سرور بیگ بلو باتن در فرمت URL</li>
+<li><b>secret:</b> کد مخفی سرور بیگ بلو باتن</li>
+<li><b>cap_sessions:</b> شمار نسبی نشست هایی که سرور میتواند میزبان باشد</li>
+<li><b>cap_users:</b> شمار نسبی کاربرانی که سرور میتواند میزبان باشد </li>";
 
 $string['config_server_selection_method'] = 'روش انتخاب سرور';
 $string['config_server_selection_method_description'] =

--- a/mod_form.php
+++ b/mod_form.php
@@ -45,7 +45,8 @@ class mod_bigbluebuttonbn_mod_form extends moodleform_mod {
     public function definition() {
         global $CFG, $DB, $OUTPUT, $PAGE;
         // Validates if the BigBlueButton server is running.
-        $serverversion = bigbluebuttonbn_get_server_version();
+        $defaultServer = bigbluebuttonbn_getDefaultServer();
+        $serverversion = bigbluebuttonbn_get_server_version($defaultServer);
         if (is_null($serverversion)) {
             print_error('general_error_unable_connect', 'bigbluebuttonbn',
                 $CFG->wwwroot.'/admin/settings.php?section=modsettingbigbluebuttonbn');

--- a/version.php
+++ b/version.php
@@ -26,9 +26,9 @@
 
 defined('MOODLE_INTERNAL') || die;
 
-$plugin->version = 2019042012;
+$plugin->version = 2022020200;
 $plugin->requires = 2016120500;
 $plugin->cron = 0;
 $plugin->component = 'mod_bigbluebuttonbn';
-$plugin->maturity = MATURITY_STABLE;
-$plugin->release = '2.3.7';
+$plugin->maturity = MATURITY_ALPHA;
+$plugin->release = '2.3.7.ms';

--- a/version.php
+++ b/version.php
@@ -26,9 +26,9 @@
 
 defined('MOODLE_INTERNAL') || die;
 
-$plugin->version = 2022020200;
+$plugin->version = 2022020202;
 $plugin->requires = 2016120500;
 $plugin->cron = 0;
 $plugin->component = 'mod_bigbluebuttonbn';
-$plugin->maturity = MATURITY_ALPHA;
+$plugin->maturity = MATURITY_BETA;
 $plugin->release = '2.3.7.ms';

--- a/view.php
+++ b/view.php
@@ -31,6 +31,8 @@ require(__DIR__.'/../../config.php');
 require_once(__DIR__.'/locallib.php');
 require_once(__DIR__.'/viewlib.php');
 
+global $DB, $PAGE, $SESSION;
+
 $id = required_param('id', PARAM_INT);
 $bn = optional_param('bn', 0, PARAM_INT);
 $group = optional_param('group', 0, PARAM_INT);
@@ -54,11 +56,13 @@ $bbbsession['course'] = $course;
 $bbbsession['coursename'] = $course->fullname;
 $bbbsession['cm'] = $cm;
 $bbbsession['bigbluebuttonbn'] = $bigbluebuttonbn;
+$bbbsession['server'] = $DB->get_record('bigbluebuttonbn_servers', ['servername' => $bigbluebuttonbn->servername]);
+
 // In locallib.
 mod_bigbluebuttonbn\locallib\bigbluebutton::view_bbbsession_set($PAGE->context, $bbbsession);
 
 // Validates if the BigBlueButton server is working.
-$serverversion = bigbluebuttonbn_get_server_version();  // In locallib.
+$serverversion = bigbluebuttonbn_get_server_version($bbbsession['server']);  // In locallib.
 if ($serverversion === null) {
     $errmsg = 'view_error_unable_join_student';
     $errurl = '/course/view.php';


### PR DESCRIPTION
 # Plugin-level scaling solution satisfying #536
The changes allow the admins to define more than one bigbluebutton server for the plugin. The plugin would allocate one of the defined servers to each BBB session with the following methods, as it is defined:
1. Server with the lowest count of sessions planned to be held in the holding period, rather than the server's capacity.
2. Server with the lowest count of participants, in all the holding sessions, in the holding period, rather than the server's capacity.

 ## Configuring servers
Servers configuration requires not only server's _url_ and _shared_secret_ but also a relative number of users and sessions that the server is able to host. Currently, a simple customized text editor is used for servers configuration but in the future, it will be substituted with a desirable dynamic input form.

![Screenshot from 2022-02-02 20-33-08](https://user-images.githubusercontent.com/70434954/152203411-77dd3f6f-6374-4a20-a599-c01ee0e0acbe.png)

