### PR TITLE
CONTRIB-8955: Fix show imported links only logic

### DIFF
--- a/classes/instance.php
+++ b/classes/instance.php
@@ -764,6 +764,18 @@ EOF;
     }
 
     /**
+     * Get recordings_imported from instancedata.
+     *
+     * @return bool
+     */
+    public function get_recordings_imported(): bool {
+        if (config::get('recordings_imported_editable')) {
+            return (bool) $this->get_instance_var('recordings_imported');
+        }
+        return config::get('recordings_imported_default');
+    }
+
+    /**
      * Whether this instance is recorded from the start.
      *
      * @return bool

--- a/classes/local/bigbluebutton/recordings/recording_data.php
+++ b/classes/local/bigbluebutton/recordings/recording_data.php
@@ -296,6 +296,10 @@ class recording_data {
         if ($rec->get('imported')) {
             return true;
         }
+        // When show imported recordings only is enabled, exclude all other recordings.
+        if ($instance->get_recordings_imported() && !$rec->get('imported')) {
+            return false;
+        }
         // Administrators and moderators are always allowed.
         if ($instance->is_admin() || $instance->is_moderator()) {
             return true;


### PR DESCRIPTION
* When Show imported links only is enabled in activity or config, only imported recordings will appear
* Logic for activity/default overrides implemented