### PR TITLE
CONTRIB-9044: Fix JWT library use

### DIFF
--- a/bbb_broker.php
+++ b/bbb_broker.php
@@ -28,7 +28,6 @@
 // phpcs:disable moodle.Files.MoodleInternal.MoodleInternalGlobalState,moodle.Files.RequireLogin.Missing
 require(__DIR__ . '/../../config.php');
 
-use Firebase\JWT\Key;
 use mod_bigbluebuttonbn\broker;
 use mod_bigbluebuttonbn\instance;
 use mod_bigbluebuttonbn\local\config;

--- a/classes/broker.php
+++ b/classes/broker.php
@@ -18,7 +18,6 @@ namespace mod_bigbluebuttonbn;
 
 use Exception;
 use Firebase\JWT\JWT;
-use Firebase\JWT\Key;
 use mod_bigbluebuttonbn\local\config;
 
 /**
@@ -89,7 +88,8 @@ class broker {
         try {
             $decodedparameters = JWT::decode(
                 $params['signed_parameters'],
-                new Key(config::get('shared_secret'), 'HS256')
+                config::get('shared_secret'),
+                array('HS256')
             );
         } catch (Exception $e) {
             $error = 'Caught exception: ' . $e->getMessage();


### PR DESCRIPTION
Use JWT library classes included in Moodle 311 and not the ones in 4.0+